### PR TITLE
Upload profile image

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,13 @@
+.angular
+.github
+.eslintrc.json
+.vscode
+CODE_OF_CONDUCT.md
+CODE_REVIEW_GUIDELINES.md
+CONTRIBUTING.md
+PROJECT_GOALS.md
+TASKS.md
+README.md
 functions/.eslintrc.js
+package-lock.json
+www

--- a/functions/src/database/groups/triggers/onUpdate/index.ts
+++ b/functions/src/database/groups/triggers/onUpdate/index.ts
@@ -1,0 +1,72 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import * as logger from "firebase-functions/logger";
+
+// Initialize the Firebase admin SDK
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+// Reference to the Firestore database
+const db = admin.firestore();
+
+// Triggered when a group is updated in Firestore
+export const onGroupUpdate = functions.firestore
+  .document("groups/{groupId}")
+  .onUpdate(handleGroupUpdate);
+
+/**
+ * Asynchronously handles the update of groups in the database.
+ * This function updates all associated relationships for the updated group.
+ * @param {Object} change - Contains before and after states of the updated group document.
+ * @param {Object} context - The context in which the function is run, including event context.
+ * @return {Promise<void>} - Returns a promise that resolves when the operation is complete
+ */
+async function handleGroupUpdate(
+  change: functions.Change<functions.firestore.DocumentSnapshot>,
+  context: any,
+) {
+  try {
+    const groupId = context.params.groupId;
+    const beforeData = change.before.data();
+    const afterData = change.after.data();
+
+    // Check if tagline, name, or logoImage fields have changed
+    if (
+      beforeData?.tagline !== afterData?.tagline ||
+      beforeData?.name !== afterData?.name ||
+      beforeData?.logoImage !== afterData?.logoImage
+    ) {
+      // Query for relationships where the relatedIds field contains the groupId
+      const querySnapshot = await db
+        .collection("relationships")
+        .where("relatedIds", "array-contains", groupId)
+        .get();
+
+      // Create a batch to handle the update of all associated relationships
+      const batch = db.batch();
+
+      querySnapshot.forEach((doc) => {
+        // Update the relationship fields.
+        if (doc.data().senderId === groupId) {
+          batch.update(doc.ref, {
+            senderTagline: afterData?.tagline,
+            senderName: afterData?.name,
+            senderImage: afterData?.logoImage,
+          });
+        } else if (doc.data().receiverId === groupId) {
+          batch.update(doc.ref, {
+            receiverTagline: afterData?.tagline,
+            receiverName: afterData?.name,
+            receiverImage: afterData?.logoImage,
+          });
+        }
+      });
+
+      // Commit the batch
+      await batch.commit();
+    }
+  } catch (error) {
+    logger.error("Error updating associated relationships: ", error);
+    // Just log the error. Throwing an error in a Firestore trigger won't propagate it to the client.
+  }
+}

--- a/functions/src/database/groups/triggers/onUpdate/index.ts
+++ b/functions/src/database/groups/triggers/onUpdate/index.ts
@@ -1,3 +1,22 @@
+/**
+* Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+* Copyright (C) 2023  ASCENDynamics NFP
+*
+* This file is part of Nonprofit Social Networking Platform.
+*
+* Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+
+* You should have received a copy of the GNU Affero General Public License
+* along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+***********************************************************************************************/
 import * as functions from "firebase-functions";
 import * as admin from "firebase-admin";
 import * as logger from "firebase-functions/logger";

--- a/functions/src/database/users/triggers/onUpdate/index.ts
+++ b/functions/src/database/users/triggers/onUpdate/index.ts
@@ -1,3 +1,22 @@
+/**
+* Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+* Copyright (C) 2023  ASCENDynamics NFP
+*
+* This file is part of Nonprofit Social Networking Platform.
+*
+* Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+
+* You should have received a copy of the GNU Affero General Public License
+* along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+***********************************************************************************************/
 import * as functions from "firebase-functions";
 import * as admin from "firebase-admin";
 import * as logger from "firebase-functions/logger";

--- a/functions/src/database/users/triggers/onUpdate/index.ts
+++ b/functions/src/database/users/triggers/onUpdate/index.ts
@@ -1,0 +1,72 @@
+import * as functions from "firebase-functions";
+import * as admin from "firebase-admin";
+import * as logger from "firebase-functions/logger";
+
+// Initialize the Firebase admin SDK
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+// Reference to the Firestore database
+const db = admin.firestore();
+
+// Triggered when a user is updated in Firestore
+export const onUserUpdate = functions.firestore
+  .document("users/{userId}")
+  .onUpdate(handleUserUpdate);
+
+/**
+ * Asynchronously handles the update of users in the database.
+ * This function updates all associated relationships for the updated user.
+ * @param {Object} change - Contains before and after states of the updated user document.
+ * @param {Object} context - The context in which the function is run, including event context.
+ * @return {Promise<void>} - Returns a promise that resolves when the operation is complete
+ */
+async function handleUserUpdate(
+  change: functions.Change<functions.firestore.DocumentSnapshot>,
+  context: any,
+) {
+  try {
+    const userId = context.params.userId;
+    const beforeData = change.before.data();
+    const afterData = change.after.data();
+
+    // Check if tagline, name, or logoImage fields have changed
+    if (
+      beforeData?.tagline !== afterData?.tagline ||
+      beforeData?.name !== afterData?.name ||
+      beforeData?.profilePicture !== afterData?.profilePicture
+    ) {
+      // Query for relationships where the relatedIds field contains the userId
+      const querySnapshot = await db
+        .collection("relationships")
+        .where("relatedIds", "array-contains", userId)
+        .get();
+
+      // Create a batch to handle the update of all associated relationships
+      const batch = db.batch();
+
+      querySnapshot.forEach((doc) => {
+        // Update the relationship fields based on whether the user is the sender or receiver.
+        if (doc.data().senderId === userId) {
+          batch.update(doc.ref, {
+            senderTagline: afterData?.tagline,
+            senderName: afterData?.name,
+            senderImage: afterData?.profilePicture,
+          });
+        } else if (doc.data().receiverId === userId) {
+          batch.update(doc.ref, {
+            receiverTagline: afterData?.tagline,
+            receiverName: afterData?.name,
+            receiverImage: afterData?.profilePicture,
+          });
+        }
+      });
+
+      // Commit the batch
+      await batch.commit();
+    }
+  } catch (error) {
+    logger.error("Error updating associated relationships: ", error);
+    // Just log the error. Throwing an error in a Firestore trigger won't propagate it to the client.
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -41,7 +41,7 @@ export * from "./auth/user/triggers/onCreate"; // triggers
 export * from "./auth/user/triggers/onDelete"; // triggers
 export * from "./database/relationships/triggers"; // triggers
 export * from "./database/groups/triggers/onCreate"; // triggers
-// export * from "./database/groups/triggers/onUpdate"; // triggers
+export * from "./database/groups/triggers/onUpdate"; // triggers
 export * from "./database/groups/triggers/onDelete"; // triggers
 // export * from "./database/users/triggers/onCreate"; // triggers
 // export * from "./database/users/triggers/onUpdate"; // triggers

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -44,5 +44,5 @@ export * from "./database/groups/triggers/onCreate"; // triggers
 export * from "./database/groups/triggers/onUpdate"; // triggers
 export * from "./database/groups/triggers/onDelete"; // triggers
 // export * from "./database/users/triggers/onCreate"; // triggers
-// export * from "./database/users/triggers/onUpdate"; // triggers
+export * from "./database/users/triggers/onUpdate"; // triggers
 export * from "./database/users/triggers/onDelete"; // triggers

--- a/src/app/core/services/image-upload.service.spec.ts
+++ b/src/app/core/services/image-upload.service.spec.ts
@@ -1,3 +1,22 @@
+/***********************************************************************************************
+* Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+* Copyright (C) 2023  ASCENDynamics NFP
+*
+* This file is part of Nonprofit Social Networking Platform.
+*
+* Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+
+* You should have received a copy of the GNU Affero General Public License
+* along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+***********************************************************************************************/
 import {TestBed} from "@angular/core/testing";
 
 import {ImageUploadService} from "./image-upload.service";

--- a/src/app/core/services/image-upload.service.spec.ts
+++ b/src/app/core/services/image-upload.service.spec.ts
@@ -1,0 +1,16 @@
+import {TestBed} from "@angular/core/testing";
+
+import {ImageUploadService} from "./image-upload.service";
+
+describe("ImageUploadService", () => {
+  let service: ImageUploadService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ImageUploadService);
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/core/services/image-upload.service.ts
+++ b/src/app/core/services/image-upload.service.ts
@@ -1,3 +1,22 @@
+/***********************************************************************************************
+* Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+* Copyright (C) 2023  ASCENDynamics NFP
+*
+* This file is part of Nonprofit Social Networking Platform.
+*
+* Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+
+* You should have received a copy of the GNU Affero General Public License
+* along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+***********************************************************************************************/
 import {Injectable} from "@angular/core";
 import {LoadingController, ToastController} from "@ionic/angular";
 import {

--- a/src/app/core/services/image-upload.service.ts
+++ b/src/app/core/services/image-upload.service.ts
@@ -1,0 +1,132 @@
+import {Injectable} from "@angular/core";
+import {LoadingController, ToastController} from "@ionic/angular";
+import {
+  getStorage,
+  ref,
+  uploadBytesResumable,
+  getDownloadURL,
+} from "firebase/storage";
+import {StoreService} from "./store.service";
+
+@Injectable({
+  providedIn: "root",
+})
+export class ImageUploadService {
+  storage = getStorage();
+
+  constructor(
+    private loadingController: LoadingController,
+    private storeService: StoreService,
+    private toastController: ToastController,
+  ) {}
+
+  async uploadImage(
+    file: File,
+    firestoreLocation: string,
+    collectionName: string,
+    docId: string,
+    maxWidth: number,
+    maxHeight: number,
+  ): Promise<string> {
+    const loading = await this.loadingController.create({
+      message: "Starting upload...",
+    });
+    await loading.present();
+
+    const resizedImageBlob = await this.resizeImage(file, maxWidth, maxHeight);
+    const filePath = `${firestoreLocation}/${file.name}`;
+    const storageRef = ref(this.storage, filePath);
+    const uploadTask = uploadBytesResumable(storageRef, resizedImageBlob);
+
+    return new Promise((resolve, reject) => {
+      uploadTask.on(
+        "state_changed",
+        (snapshot) => {
+          const progress =
+            (snapshot.bytesTransferred / snapshot.totalBytes) * 100;
+          switch (snapshot.state) {
+            case "paused":
+              loading.message = `Upload is paused`;
+              break;
+            case "running":
+              loading.message = `Uploading file... ${progress.toFixed(0)}%`;
+              break;
+          }
+        },
+        async (error) => {
+          loading.dismiss();
+          this.showErrorToast(`Upload failed: ${error.message}`);
+          reject(error.message);
+        },
+        async () => {
+          const downloadURL = await getDownloadURL(uploadTask.snapshot.ref);
+          await this.saveImageToFirestore(collectionName, docId, downloadURL);
+          loading.dismiss();
+          resolve(downloadURL);
+        },
+      );
+    });
+  }
+
+  private async saveImageToFirestore(
+    collectionName: string,
+    docId: string,
+    downloadURL: string,
+  ) {
+    await this.storeService.updateDoc(collectionName, {
+      id: docId,
+      profilePicture: downloadURL,
+    });
+  }
+
+  private async showErrorToast(message: string) {
+    const toast = await this.toastController.create({
+      message: message,
+      duration: 2000,
+      color: "danger",
+    });
+    toast.present();
+  }
+
+  private resizeImage(
+    file: File,
+    maxWidth: number,
+    maxHeight: number,
+  ): Promise<Blob> {
+    return new Promise((resolve, reject) => {
+      const image = new Image();
+      image.src = URL.createObjectURL(file);
+      image.onload = () => {
+        const canvas = document.createElement("canvas");
+        const ctx = canvas.getContext("2d");
+        let width = image.width;
+        let height = image.height;
+
+        if (width > height) {
+          if (width > maxWidth) {
+            height *= maxWidth / width;
+            width = maxWidth;
+          }
+        } else {
+          if (height > maxHeight) {
+            width *= maxHeight / height;
+            height = maxHeight;
+          }
+        }
+        canvas.width = width;
+        canvas.height = height;
+        ctx!.drawImage(image, 0, 0, width, height);
+
+        canvas.toBlob(
+          (blob) => {
+            resolve(blob!);
+          },
+          "image/jpeg",
+          0.95,
+        );
+      };
+      image.onerror = (error) =>
+        reject(new Error(`Image load error: ${error}`));
+    });
+  }
+}

--- a/src/app/modules/group/pages/group-profile/components/hero/hero.component.html
+++ b/src/app/modules/group/pages/group-profile/components/hero/hero.component.html
@@ -18,11 +18,21 @@ You should have received a copy of the GNU Affero General Public License
 along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <ion-card *ngIf="group">
-  <img width="100%" [alt]="group.name" [src]="group.heroImage" />
+  <img
+    class="hero"
+    width="100%"
+    [alt]="group.name"
+    [src]="group.heroImage"
+    (click)="openImageUploadModal('heroImage')"
+  />
   <ion-card-header>
     <ion-item lines="none">
       <ion-thumbnail *ngIf="group.logoImage" slot="start">
-        <img [src]="group.logoImage" [alt]="group.name" />
+        <img
+          [src]="group.logoImage"
+          [alt]="group.name"
+          (click)="openImageUploadModal('logoImage')"
+        />
       </ion-thumbnail>
       <ion-label>
         <ion-card-title>{{ group.name }}</ion-card-title>

--- a/src/app/modules/group/pages/group-profile/components/hero/hero.component.html
+++ b/src/app/modules/group/pages/group-profile/components/hero/hero.component.html
@@ -18,8 +18,7 @@ You should have received a copy of the GNU Affero General Public License
 along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <ion-card *ngIf="group">
-  <img class="hero-image" width="100%" [alt]="group.name" [src]="group.heroImage"
-    (click)="openImageUploadModal('heroImage')" />
+  <img class="hero-image" [alt]="group.name" [src]="group.heroImage" (click)="openImageUploadModal('heroImage')" />
   <ion-card-header>
     <ion-item lines="none">
       <ion-thumbnail *ngIf="group.logoImage" slot="start">

--- a/src/app/modules/group/pages/group-profile/components/hero/hero.component.html
+++ b/src/app/modules/group/pages/group-profile/components/hero/hero.component.html
@@ -18,21 +18,12 @@ You should have received a copy of the GNU Affero General Public License
 along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <ion-card *ngIf="group">
-  <img
-    class="hero"
-    width="100%"
-    [alt]="group.name"
-    [src]="group.heroImage"
-    (click)="openImageUploadModal('heroImage')"
-  />
+  <img class="hero-image" width="100%" [alt]="group.name" [src]="group.heroImage"
+    (click)="openImageUploadModal('heroImage')" />
   <ion-card-header>
     <ion-item lines="none">
       <ion-thumbnail *ngIf="group.logoImage" slot="start">
-        <img
-          [src]="group.logoImage"
-          [alt]="group.name"
-          (click)="openImageUploadModal('logoImage')"
-        />
+        <img [src]="group.logoImage" [alt]="group.name" (click)="openImageUploadModal('logoImage')" />
       </ion-thumbnail>
       <ion-label>
         <ion-card-title>{{ group.name }}</ion-card-title>
@@ -49,11 +40,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
     <ion-card-title>Description</ion-card-title>
     <ion-item lines="none">
       <p>
-        <ion-textarea
-          [readonly]="true"
-          [autoGrow]="true"
-          [value]="group.description"
-        >
+        <ion-textarea [readonly]="true" [autoGrow]="true" [value]="group.description">
         </ion-textarea>
       </p>
     </ion-item>

--- a/src/app/modules/group/pages/group-profile/components/hero/hero.component.html
+++ b/src/app/modules/group/pages/group-profile/components/hero/hero.component.html
@@ -18,11 +18,20 @@ You should have received a copy of the GNU Affero General Public License
 along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <ion-card *ngIf="group">
-  <img class="hero-image" [alt]="group.name" [src]="group.heroImage" (click)="openImageUploadModal('heroImage')" />
+  <img
+    class="hero-image"
+    [alt]="group.name"
+    [src]="group.heroImage"
+    (click)="openImageUploadModal('heroImage')"
+  />
   <ion-card-header>
     <ion-item lines="none">
       <ion-thumbnail *ngIf="group.logoImage" slot="start">
-        <img [src]="group.logoImage" [alt]="group.name" (click)="openImageUploadModal('logoImage')" />
+        <img
+          [src]="group.logoImage"
+          [alt]="group.name"
+          (click)="openImageUploadModal('logoImage')"
+        />
       </ion-thumbnail>
       <ion-label>
         <ion-card-title>{{ group.name }}</ion-card-title>
@@ -39,7 +48,11 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
     <ion-card-title>Description</ion-card-title>
     <ion-item lines="none">
       <p>
-        <ion-textarea [readonly]="true" [autoGrow]="true" [value]="group.description">
+        <ion-textarea
+          [readonly]="true"
+          [autoGrow]="true"
+          [value]="group.description"
+        >
         </ion-textarea>
       </p>
     </ion-item>

--- a/src/app/modules/group/pages/group-profile/components/hero/hero.component.scss
+++ b/src/app/modules/group/pages/group-profile/components/hero/hero.component.scss
@@ -17,3 +17,7 @@
 * You should have received a copy of the GNU Affero General Public License
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
+img.hero {
+  /* set the max-height to 1/3 of the width on small devices and */
+  max-height: calc(100vw / 3);
+}

--- a/src/app/modules/group/pages/group-profile/components/hero/hero.component.scss
+++ b/src/app/modules/group/pages/group-profile/components/hero/hero.component.scss
@@ -17,7 +17,7 @@
 * You should have received a copy of the GNU Affero General Public License
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
-img.hero {
+img.hero-image {
   /* set the max-height to 1/3 of the width on small devices and */
   max-height: calc(100vw / 3);
 }

--- a/src/app/modules/group/pages/group-profile/components/hero/hero.component.scss
+++ b/src/app/modules/group/pages/group-profile/components/hero/hero.component.scss
@@ -18,6 +18,10 @@
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
 img.hero-image {
-  /* set the max-height to 1/3 of the width on small devices and */
+  width: 100%;
+  /* set the max-height to 1/3 of the width */
   max-height: calc(100vw / 3);
+  /* center image and crop it */
+  object-fit: cover;
+  object-position: center;
 }

--- a/src/app/modules/group/pages/group-profile/components/hero/hero.component.ts
+++ b/src/app/modules/group/pages/group-profile/components/hero/hero.component.ts
@@ -18,22 +18,66 @@
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
 import {CommonModule} from "@angular/common";
-import {Component, Input, OnInit} from "@angular/core";
-import {IonicModule} from "@ionic/angular";
+import {Component, Input} from "@angular/core";
+import {IonicModule, ModalController} from "@ionic/angular";
 import {AppGroup} from "../../../../../../models/group.model";
+import {ImageUploadModalComponent} from "../../../../../../shared/components/image-upload-modal/image-upload-modal.component";
 
 @Component({
   selector: "app-hero",
   templateUrl: "./hero.component.html",
   styleUrls: ["./hero.component.scss"],
   standalone: true,
-  imports: [IonicModule, CommonModule],
+  imports: [IonicModule, CommonModule, ImageUploadModalComponent],
 })
-export class HeroComponent implements OnInit {
+export class HeroComponent {
   @Input() group: Partial<AppGroup> | null = null; // define your user here
+  @Input() isAdmin: boolean = false;
   @Input() isMember: boolean = false;
   @Input() isPendingMember: boolean = false;
-  constructor() {}
 
-  ngOnInit() {}
+  constructor(private modalController: ModalController) {}
+
+  async openImageUploadModal(imageType: string) {
+    if (!this.group?.id || !this.isAdmin) return;
+    if (imageType === "heroImage") {
+      let modal = await this.modalController.create({
+        component: ImageUploadModalComponent,
+        componentProps: {
+          collectionName: "groups",
+          docId: this.group?.id,
+          firestoreLocation: `groups/${this.group?.id}/profile`,
+          maxHeight: 300,
+          maxWidth: 900,
+          fieldName: "heroImage",
+        },
+      });
+
+      await modal.present();
+
+      // const {data} = await modal.onWillDismiss();
+      // if (data) {
+      //   const profileImageUrl = data;
+      // }
+    } else if (imageType === "logoImage") {
+      let modal = await this.modalController.create({
+        component: ImageUploadModalComponent,
+        componentProps: {
+          collectionName: "groups",
+          docId: this.group?.id,
+          firestoreLocation: `groups/${this.group?.id}/profile`,
+          maxHeight: 200,
+          maxWidth: 200,
+          fieldName: "logoImage",
+        },
+      });
+
+      await modal.present();
+
+      // const {data} = await modal.onWillDismiss();
+      // if (data) {
+      //   const profileImageUrl = data;
+      // }
+    }
+  }
 }

--- a/src/app/modules/group/pages/group-profile/group-profile.page.html
+++ b/src/app/modules/group/pages/group-profile/group-profile.page.html
@@ -40,6 +40,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
           [group]="group"
           [isMember]="isMember"
           [isPendingMember]="isPendingMember"
+          [isAdmin]="isAdmin"
         ></app-hero>
       </ion-col>
     </ion-row>

--- a/src/app/modules/user/pages/user-profile/components/details/details.component.html
+++ b/src/app/modules/user/pages/user-profile/components/details/details.component.html
@@ -23,7 +23,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
   </ion-card-header>
   <ion-card-content>
     <ion-list>
-      <ion-item lines="none">
+      <!-- <ion-item lines="none">
         <ion-avatar slot="start">
           <img [src]="user.profilePicture" alt="Profile Picture" />
         </ion-avatar>
@@ -31,13 +31,11 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
           <h2>{{ user.displayName }}</h2>
           <p>{{ user.email }}</p>
         </ion-label>
-      </ion-item>
+      </ion-item> -->
 
       <ion-item lines="none">
         <ion-icon name="mail" slot="start"></ion-icon>
-        <ion-label
-          >Email Verified: {{ user.emailVerified ? "Yes" : "No" }}</ion-label
-        >
+        <ion-label>Email: {{ user.email }}</ion-label>
       </ion-item>
 
       <ion-item lines="none">
@@ -53,10 +51,10 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
         <ion-label>{{user.addressFormatted}}</ion-label>
       </ion-item> -->
 
-      <ion-item lines="none">
+      <!-- <ion-item lines="none">
         <ion-icon name="text" slot="start"></ion-icon>
         <ion-label>Bio: {{ user.bio }}</ion-label>
-      </ion-item>
+      </ion-item> -->
 
       <ion-item lines="none">
         <ion-icon name="book" slot="start"></ion-icon>

--- a/src/app/modules/user/pages/user-profile/components/hero/hero.component.html
+++ b/src/app/modules/user/pages/user-profile/components/hero/hero.component.html
@@ -18,17 +18,30 @@ You should have received a copy of the GNU Affero General Public License
 along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <ion-card *ngIf="user">
-  <img class="hero-image" (click)="openImageUploadModal('heroImage')" [alt]="user.displayName" [src]="user.heroImage" />
+  <img
+    class="hero-image"
+    (click)="openImageUploadModal('heroImage')"
+    [alt]="user.displayName"
+    [src]="user.heroImage"
+  />
   <ion-card-header>
-    <ion-item>
+    <ion-item lines="none">
       <ion-avatar slot="start" (click)="openImageUploadModal('profilePicture')">
         <img [alt]="user.name" [src]="user.profilePicture" />
       </ion-avatar>
-      <ion-label>{{ user.tagline }}</ion-label>
+      <ion-label>
+        <ion-card-title>{{ user.tagline }}</ion-card-title>
+        <!-- <p>{{ user.freinds.length }}</p> -->
+        <ion-card-subtitle>### Hours Volunteer</ion-card-subtitle>
+      </ion-label>
+    </ion-item>
+    <ion-item lines="none">
+      <p>
+        <ion-textarea [readonly]="true" [autoGrow]="true" [value]="user.bio">
+        </ion-textarea>
+      </p>
     </ion-item>
   </ion-card-header>
 
-  <ion-card-content *ngIf="user.bio">
-    {{ user.bio }}
-  </ion-card-content>
+  <ion-card-content *ngIf="user.bio"> </ion-card-content>
 </ion-card>

--- a/src/app/modules/user/pages/user-profile/components/hero/hero.component.html
+++ b/src/app/modules/user/pages/user-profile/components/hero/hero.component.html
@@ -18,11 +18,16 @@ You should have received a copy of the GNU Affero General Public License
 along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <ion-card *ngIf="user">
-  <img width="100%" [alt]="user.displayName" [src]="user.heroImage" />
+  <img
+    (click)="openImageUploadModal('heroImage')"
+    width="100%"
+    [alt]="user.displayName"
+    [src]="user.heroImage"
+  />
   <ion-card-header>
     <ion-item>
-      <ion-avatar slot="start" (click)="openImageUploadModal()">
-        <img alt="Silhouette of a person's head" [src]="user.profilePicture" />
+      <ion-avatar slot="start" (click)="openImageUploadModal('profilePicture')">
+        <img [alt]="user.name" [src]="user.profilePicture" />
       </ion-avatar>
       <ion-label>{{ user.tagline }}</ion-label>
     </ion-item>

--- a/src/app/modules/user/pages/user-profile/components/hero/hero.component.html
+++ b/src/app/modules/user/pages/user-profile/components/hero/hero.component.html
@@ -20,13 +20,15 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
 <ion-card *ngIf="user">
   <img width="100%" [alt]="user.displayName" [src]="user.heroImage" />
   <ion-card-header>
-    <ion-card-title>{{ user.displayName }}</ion-card-title>
-    <ion-card-subtitle>101 Hours Volunteer</ion-card-subtitle>
-    <!-- <p>Email: {{ user.email }}</p>
-    <p>Email Verified: {{ user.emailVerified }}</p> -->
+    <ion-item>
+      <ion-avatar slot="start" (click)="openImageUploadModal()">
+        <img alt="Silhouette of a person's head" [src]="user.profilePicture" />
+      </ion-avatar>
+      <ion-label>{{ user.tagline }}</ion-label>
+    </ion-item>
   </ion-card-header>
 
-  <!-- <ion-card-content>
-    Here's a small text description for the card content. Nothing more, nothing less.
-  </ion-card-content> -->
+  <ion-card-content *ngIf="user.bio">
+    {{ user.bio }}
+  </ion-card-content>
 </ion-card>

--- a/src/app/modules/user/pages/user-profile/components/hero/hero.component.html
+++ b/src/app/modules/user/pages/user-profile/components/hero/hero.component.html
@@ -18,12 +18,7 @@ You should have received a copy of the GNU Affero General Public License
 along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 -->
 <ion-card *ngIf="user">
-  <img
-    (click)="openImageUploadModal('heroImage')"
-    width="100%"
-    [alt]="user.displayName"
-    [src]="user.heroImage"
-  />
+  <img class="hero-image" (click)="openImageUploadModal('heroImage')" [alt]="user.displayName" [src]="user.heroImage" />
   <ion-card-header>
     <ion-item>
       <ion-avatar slot="start" (click)="openImageUploadModal('profilePicture')">

--- a/src/app/modules/user/pages/user-profile/components/hero/hero.component.scss
+++ b/src/app/modules/user/pages/user-profile/components/hero/hero.component.scss
@@ -21,7 +21,7 @@ img.hero-image {
   width: 100%;
   /* set the max-height to 1/3 of the width */
   max-height: calc(100vw / 3);
-/* center image and crop it */
+  /* center image and crop it */
   object-fit: cover;
   object-position: center;
 }

--- a/src/app/modules/user/pages/user-profile/components/hero/hero.component.scss
+++ b/src/app/modules/user/pages/user-profile/components/hero/hero.component.scss
@@ -17,3 +17,7 @@
 * You should have received a copy of the GNU Affero General Public License
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
+img.hero-image {
+    /* set the max-height to 1/3 of the width on small devices and */
+    max-height: calc(100vw / 3);
+  }

--- a/src/app/modules/user/pages/user-profile/components/hero/hero.component.scss
+++ b/src/app/modules/user/pages/user-profile/components/hero/hero.component.scss
@@ -18,6 +18,10 @@
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
 img.hero-image {
-    /* set the max-height to 1/3 of the width on small devices and */
-    max-height: calc(100vw / 3);
-  }
+  width: 100%;
+  /* set the max-height to 1/3 of the width */
+  max-height: calc(100vw / 3);
+/* center image and crop it */
+  object-fit: cover;
+  object-position: center;
+}

--- a/src/app/modules/user/pages/user-profile/components/hero/hero.component.ts
+++ b/src/app/modules/user/pages/user-profile/components/hero/hero.component.ts
@@ -45,8 +45,8 @@ export class HeroComponent {
           collectionName: "users",
           docId: this.user?.id,
           firestoreLocation: `users/${this.user?.id}/profile`,
-          maxHeight: 200,
-          maxWidth: 200,
+          maxHeight: 300,
+          maxWidth: 900,
           fieldName: "heroImage",
         },
       });
@@ -64,8 +64,8 @@ export class HeroComponent {
           collectionName: "users",
           docId: this.user?.id,
           firestoreLocation: `users/${this.user?.id}/profile`,
-          maxHeight: 300,
-          maxWidth: 900,
+          maxHeight: 200,
+          maxWidth: 200,
           fieldName: "profilePicture",
         },
       });

--- a/src/app/modules/user/pages/user-profile/components/hero/hero.component.ts
+++ b/src/app/modules/user/pages/user-profile/components/hero/hero.component.ts
@@ -18,21 +18,40 @@
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
 import {CommonModule} from "@angular/common";
-import {Component, Input, OnInit} from "@angular/core";
-import {IonicModule} from "@ionic/angular";
+import {Component, Input} from "@angular/core";
+import {IonicModule, ModalController} from "@ionic/angular";
 import {AppUser} from "../../../../../../models/user.model"; // import your user model
+import {ImageUploadModalComponent} from "../../../../../../shared/components/image-upload-modal/image-upload-modal.component";
 
 @Component({
   selector: "app-hero",
   templateUrl: "./hero.component.html",
   styleUrls: ["./hero.component.scss"],
   standalone: true,
-  imports: [IonicModule, CommonModule],
+  imports: [IonicModule, CommonModule, ImageUploadModalComponent],
 })
-export class HeroComponent implements OnInit {
-  @Input() user: Partial<AppUser> | null = null; // define your user here
+export class HeroComponent {
+  @Input() user?: Partial<AppUser>; // define your user here
 
-  constructor() {}
+  constructor(private modalController: ModalController) {}
 
-  ngOnInit() {}
+  async openImageUploadModal() {
+    const modal = await this.modalController.create({
+      component: ImageUploadModalComponent,
+      componentProps: {
+        collectionName: "users",
+        docId: this.user?.id,
+        firestoreLocation: `users/${this.user?.id}/profile`,
+        maxHeight: 200,
+        maxWidth: 200,
+      },
+    });
+
+    await modal.present();
+
+    const {data} = await modal.onWillDismiss();
+    if (data) {
+      const profileImageUrl = data;
+    }
+  }
 }

--- a/src/app/modules/user/pages/user-profile/components/hero/hero.component.ts
+++ b/src/app/modules/user/pages/user-profile/components/hero/hero.component.ts
@@ -32,26 +32,50 @@ import {ImageUploadModalComponent} from "../../../../../../shared/components/ima
 })
 export class HeroComponent {
   @Input() user?: Partial<AppUser>; // define your user here
+  @Input() isProfileOwner: boolean = false; // define if the user is the current user (for edit profile button
 
   constructor(private modalController: ModalController) {}
 
-  async openImageUploadModal() {
-    const modal = await this.modalController.create({
-      component: ImageUploadModalComponent,
-      componentProps: {
-        collectionName: "users",
-        docId: this.user?.id,
-        firestoreLocation: `users/${this.user?.id}/profile`,
-        maxHeight: 200,
-        maxWidth: 200,
-      },
-    });
+  async openImageUploadModal(imageType: string) {
+    if (!this.user?.id || !this.isProfileOwner) return;
+    if (imageType === "heroImage") {
+      let modal = await this.modalController.create({
+        component: ImageUploadModalComponent,
+        componentProps: {
+          collectionName: "users",
+          docId: this.user?.id,
+          firestoreLocation: `users/${this.user?.id}/profile`,
+          maxHeight: 200,
+          maxWidth: 200,
+          fieldName: "heroImage",
+        },
+      });
 
-    await modal.present();
+      await modal.present();
 
-    const {data} = await modal.onWillDismiss();
-    if (data) {
-      const profileImageUrl = data;
+      // const {data} = await modal.onWillDismiss();
+      // if (data) {
+      //   const profileImageUrl = data;
+      // }
+    } else if (imageType === "profilePicture") {
+      let modal = await this.modalController.create({
+        component: ImageUploadModalComponent,
+        componentProps: {
+          collectionName: "users",
+          docId: this.user?.id,
+          firestoreLocation: `users/${this.user?.id}/profile`,
+          maxHeight: 300,
+          maxWidth: 900,
+          fieldName: "profilePicture",
+        },
+      });
+
+      await modal.present();
+
+      // const {data} = await modal.onWillDismiss();
+      // if (data) {
+      //   const profileImageUrl = data;
+      // }
     }
   }
 }

--- a/src/app/modules/user/pages/user-profile/user-profile.page.html
+++ b/src/app/modules/user/pages/user-profile/user-profile.page.html
@@ -35,7 +35,11 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
   <ion-grid>
     <ion-row>
       <ion-col>
-        <app-hero *ngIf="user" [user]="user"></app-hero>
+        <app-hero
+          *ngIf="user"
+          [user]="user"
+          [isProfileOwner]="isProfileOwner"
+        ></app-hero>
       </ion-col>
     </ion-row>
     <ion-row>

--- a/src/app/shared/components/image-upload-modal/image-upload-modal.component.html
+++ b/src/app/shared/components/image-upload-modal/image-upload-modal.component.html
@@ -34,8 +34,12 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
           <ion-label>Select Image</ion-label>
           <ion-input type="file" (change)="onImageSelected($event)"></ion-input>
         </ion-item>
-        <img *ngIf="imagePreview" [src]="imagePreviewString" alt="Image Preview"
-          style="max-width: 100%; max-height: 70vh" />
+        <img
+          *ngIf="imagePreview"
+          [src]="imagePreviewString"
+          alt="Image Preview"
+          style="max-width: 100%; max-height: 70vh"
+        />
       </ion-col>
     </ion-row>
   </ion-grid>

--- a/src/app/shared/components/image-upload-modal/image-upload-modal.component.html
+++ b/src/app/shared/components/image-upload-modal/image-upload-modal.component.html
@@ -1,3 +1,22 @@
+<!--
+Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+Copyright (C) 2023  ASCENDynamics NFP
+
+This file is part of Nonprofit Social Networking Platform.
+
+Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+-->
 <ion-header>
   <ion-toolbar>
     <ion-title>Upload Image</ion-title>
@@ -15,12 +34,8 @@
           <ion-label>Select Image</ion-label>
           <ion-input type="file" (change)="onImageSelected($event)"></ion-input>
         </ion-item>
-        <img
-          *ngIf="imagePreview"
-          [src]="imagePreviewString"
-          alt="Image Preview"
-          style="max-width: 100%; max-height: 70vh"
-        />
+        <img *ngIf="imagePreview" [src]="imagePreviewString" alt="Image Preview"
+          style="max-width: 100%; max-height: 70vh" />
       </ion-col>
     </ion-row>
   </ion-grid>

--- a/src/app/shared/components/image-upload-modal/image-upload-modal.component.html
+++ b/src/app/shared/components/image-upload-modal/image-upload-modal.component.html
@@ -1,0 +1,31 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Upload Image</ion-title>
+    <ion-buttons slot="end">
+      <ion-button (click)="closeModal()">Close</ion-button>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content class="ion-padding">
+  <ion-grid style="height: 100%">
+    <ion-row class="ion-align-items-center" style="flex: 1">
+      <ion-col size="12" class="ion-text-center">
+        <ion-item>
+          <ion-label>Select Image</ion-label>
+          <ion-input type="file" (change)="onImageSelected($event)"></ion-input>
+        </ion-item>
+        <img
+          *ngIf="imagePreview"
+          [src]="imagePreviewString"
+          alt="Image Preview"
+          style="max-width: 100%; max-height: 70vh"
+        />
+      </ion-col>
+    </ion-row>
+  </ion-grid>
+</ion-content>
+
+<ion-footer>
+  <ion-button expand="full" (click)="uploadImage()">Upload</ion-button>
+</ion-footer>

--- a/src/app/shared/components/image-upload-modal/image-upload-modal.component.scss
+++ b/src/app/shared/components/image-upload-modal/image-upload-modal.component.scss
@@ -1,0 +1,19 @@
+/***********************************************************************************************
+* Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+* Copyright (C) 2023  ASCENDynamics NFP
+*
+* This file is part of Nonprofit Social Networking Platform.
+*
+* Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+
+* You should have received a copy of the GNU Affero General Public License
+* along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+***********************************************************************************************/

--- a/src/app/shared/components/image-upload-modal/image-upload-modal.component.spec.ts
+++ b/src/app/shared/components/image-upload-modal/image-upload-modal.component.spec.ts
@@ -1,0 +1,24 @@
+import {ComponentFixture, TestBed, waitForAsync} from "@angular/core/testing";
+import {IonicModule} from "@ionic/angular";
+
+import {ImageUploadModalComponent} from "./image-upload-modal.component";
+
+describe("ImageUploadModalComponent", () => {
+  let component: ImageUploadModalComponent;
+  let fixture: ComponentFixture<ImageUploadModalComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [],
+      imports: [IonicModule.forRoot()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ImageUploadModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/components/image-upload-modal/image-upload-modal.component.spec.ts
+++ b/src/app/shared/components/image-upload-modal/image-upload-modal.component.spec.ts
@@ -1,3 +1,22 @@
+/***********************************************************************************************
+* Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+* Copyright (C) 2023  ASCENDynamics NFP
+*
+* This file is part of Nonprofit Social Networking Platform.
+*
+* Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+
+* You should have received a copy of the GNU Affero General Public License
+* along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+***********************************************************************************************/
 import {ComponentFixture, TestBed, waitForAsync} from "@angular/core/testing";
 import {IonicModule} from "@ionic/angular";
 

--- a/src/app/shared/components/image-upload-modal/image-upload-modal.component.ts
+++ b/src/app/shared/components/image-upload-modal/image-upload-modal.component.ts
@@ -18,6 +18,7 @@ export class ImageUploadModalComponent {
   @Input() firestoreLocation!: string; // e.g. 'users/userId/profileImage'
   @Input() imageHeight!: number;
   @Input() imageWidth!: number;
+  @Input() fieldName!: string;
   imagePreview!: SafeUrl | string | ArrayBuffer;
   selectedFile: File | null = null;
 
@@ -54,6 +55,7 @@ export class ImageUploadModalComponent {
           this.docId,
           this.imageWidth,
           this.imageHeight,
+          this.fieldName,
         );
         this.modalCtrl.dismiss(downloadURL);
       } else {

--- a/src/app/shared/components/image-upload-modal/image-upload-modal.component.ts
+++ b/src/app/shared/components/image-upload-modal/image-upload-modal.component.ts
@@ -1,3 +1,22 @@
+/***********************************************************************************************
+* Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+* Copyright (C) 2023  ASCENDynamics NFP
+*
+* This file is part of Nonprofit Social Networking Platform.
+*
+* Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+
+* You should have received a copy of the GNU Affero General Public License
+* along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+***********************************************************************************************/
 import {Component, Input} from "@angular/core";
 import {ModalController, IonicModule} from "@ionic/angular";
 import {ImageUploadService} from "../../../core/services/image-upload.service"; // Adjust the path to your service

--- a/src/app/shared/components/image-upload-modal/image-upload-modal.component.ts
+++ b/src/app/shared/components/image-upload-modal/image-upload-modal.component.ts
@@ -1,0 +1,70 @@
+import {Component, Input} from "@angular/core";
+import {ModalController, IonicModule} from "@ionic/angular";
+import {ImageUploadService} from "../../../core/services/image-upload.service"; // Adjust the path to your service
+import {CommonModule} from "@angular/common";
+import {FormsModule} from "@angular/forms";
+import {DomSanitizer, SafeUrl} from "@angular/platform-browser";
+
+@Component({
+  selector: "app-image-upload-modal",
+  templateUrl: "./image-upload-modal.component.html",
+  styleUrls: ["./image-upload-modal.component.scss"],
+  standalone: true,
+  imports: [IonicModule, CommonModule, FormsModule],
+})
+export class ImageUploadModalComponent {
+  @Input() collectionName!: string;
+  @Input() docId!: string;
+  @Input() firestoreLocation!: string; // e.g. 'users/userId/profileImage'
+  @Input() imageHeight!: number;
+  @Input() imageWidth!: number;
+  imagePreview!: SafeUrl | string | ArrayBuffer;
+  selectedFile: File | null = null;
+
+  constructor(
+    private imageUploadService: ImageUploadService,
+    private modalCtrl: ModalController,
+    private sanitizer: DomSanitizer,
+  ) {}
+
+  get imagePreviewString(): string {
+    return this.imagePreview as string;
+  }
+
+  onImageSelected(event: any) {
+    const file: File = event.target.files[0];
+    this.selectedFile = file;
+    const reader = new FileReader();
+
+    reader.onload = () => {
+      const unsafeImageUrl = reader.result as string;
+      this.imagePreview = this.sanitizer.bypassSecurityTrustUrl(unsafeImageUrl);
+    };
+
+    reader.readAsDataURL(file);
+  }
+
+  async uploadImage() {
+    try {
+      if (this.selectedFile) {
+        const downloadURL = await this.imageUploadService.uploadImage(
+          this.selectedFile,
+          this.firestoreLocation,
+          this.collectionName,
+          this.docId,
+          this.imageWidth,
+          this.imageHeight,
+        );
+        this.modalCtrl.dismiss(downloadURL);
+      } else {
+        console.error("No file selected for upload.");
+      }
+    } catch (error) {
+      console.error("Error uploading image:", error);
+    }
+  }
+
+  closeModal() {
+    this.modalCtrl.dismiss();
+  }
+}


### PR DESCRIPTION
## Description

Added `ImageUploadService` and `ImageUploadModalComponent`.
Added an `onclick` on `profilePicture`, `heroImage`, `logoImage` on the `user` and `group` pages that displays the upload image modal.
Images are saved to Firestore and the fields that reference the images are updated so that the new image is displayed.

Fixes # (issue)
#74 #75 
## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] Click User picture and upload a new image.
- [ ] Click User hero image and upload a new image.
- [ ] Click Group logo picture and upload a new image.
- [ ] Click Group hero image and upload a new image.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
