### PR TITLE
Bugfix/login redirect

### DIFF
--- a/src/app/modules/user/pages/user-login/user-login.page.ts
+++ b/src/app/modules/user/pages/user-login/user-login.page.ts
@@ -36,7 +36,7 @@ import {Subscription} from "rxjs";
   imports: [IonicModule, CommonModule, ReactiveFormsModule, TranslateModule],
 })
 export class UserLoginPage {
-  private userSubscription: Subscription | undefined;
+  private userSubscription?: Subscription;
   public loginForm = this.fb.nonNullable.group({
     // Using Validators.compose() for multiple validation rules
     email: ["", Validators.compose([Validators.required, Validators.email])],
@@ -51,7 +51,21 @@ export class UserLoginPage {
     private authStoreService: AuthStoreService,
     private fb: FormBuilder,
     private router: Router, // private storeService: StoreService,
-  ) {
+  ) {}
+
+  ionViewWillEnter() {
+    this.initiateSubscribers();
+    this.loadFormData();
+    this.authStoreService.onSignInWithEmailLink();
+    // .then(async (uid) => this.updateUserLoginTime(uid));
+  }
+
+  ionViewWillLeave() {
+    this.userSubscription?.unsubscribe();
+  }
+
+  initiateSubscribers() {
+    // Redirect to user profile if user is logged in
     this.userSubscription = this.authStoreService.user$.subscribe((user) => {
       if (user) {
         console.log("GOT USER ON LOGIN");
@@ -60,16 +74,6 @@ export class UserLoginPage {
         });
       }
     });
-  }
-
-  ionViewWillEnter() {
-    this.loadFormData();
-    this.authStoreService.onSignInWithEmailLink();
-    // .then(async (uid) => this.updateUserLoginTime(uid));
-  }
-
-  ionViewWillLeave() {
-    this.userSubscription?.unsubscribe();
   }
 
   login() {


### PR DESCRIPTION
## Description

Fixed login bug where user initiates the user$ subscriber, destroys the subscriber by navigating away from the login page, then navigates to the login page and the subscriber doesn't initiate again.  Moved the subscriber logic so that the `user$` observable is subscribed to each time to user enters the login page.  This fixes the issue for the defect as we use the `user$` observable to check if the user is logged in.  If the user is logged in, we redirect them to their profile page from the login page.

Fixes # (issue)
#116 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Navigate away from the Login page, than navigate to the login page.  Login as a user using `Login with Google`, you should be redirected to your profile page.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
