### PR TITLE
added methods to clear users state data

### DIFF
--- a/src/app/core/services/firestore.service.ts
+++ b/src/app/core/services/firestore.service.ts
@@ -193,6 +193,15 @@ export class FirestoreService {
       }
     }
   }
+
+  /**
+   * Clears the data in the collectionIdsSubject.
+   * This method sets the BehaviorSubject's value to an empty array, effectively clearing its data.
+   */
+  clearCollectionIdsData() {
+    this.collectionIdsSubject.next([]);
+  }
+
   // Obserable Logic (End) //
 
   // Firebase Query Logic (Start) //

--- a/src/app/core/services/store.service.ts
+++ b/src/app/core/services/store.service.ts
@@ -119,6 +119,9 @@ export class StoreService {
         this.firestoreService.addIdToCollection("users", user.uid);
       } else {
         this.collectionsSubscription?.unsubscribe();
+        // clear all existing state data when user logs out
+        this.firestoreService.clearCollectionIdsData();
+        this.clearCollectionsData();
       }
     });
     if (currentUser) {
@@ -304,6 +307,18 @@ export class StoreService {
     const currentState = this.collectionsSubject[collectionName].getValue();
     const updatedState = currentState.filter((d) => d["id"] !== docId);
     this.collectionsSubject[collectionName].next(updatedState);
+  }
+
+  /**
+   * Clears the data in the collectionsSubject for each collection.
+   * This method sets the BehaviorSubject's value for each collection to an empty array.
+   */
+  clearCollectionsData() {
+    for (const key in this.collectionsSubject) {
+      if (this.collectionsSubject.hasOwnProperty(key)) {
+        this.collectionsSubject[key].next([]);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Description

The users state data was being carried over when a user would log out and another user would log in.  This allowed users to see what the last user had viewed.  I've added two methods to clear the existing collection Ids and collection data.  I've added these methods to the `user$` subscription in the `StoreService` so that the previous user's data is cleared from our state store when a user logged out of the application.

Fixes # (issue)
#117 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Search for users and groups.  Log out, log in as the same user or a new user, those results should no longer show in your search results unless you search for them again.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
