### PR TITLE
Privacy settings

### DIFF
--- a/functions/src/auth/user/triggers/onCreate/index.ts
+++ b/functions/src/auth/user/triggers/onCreate/index.ts
@@ -74,6 +74,7 @@ async function saveUserProfileToFirestore(
     groups: [],
     pendingFriends: [],
     pendingGroups: [],
+    privacySetting: "public",
     // ... any other fields you want to add
   };
 

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -90,7 +90,7 @@ export const routes: Routes = [
     canActivate: [SecureInnerPagesGuard],
   },
   {
-    path: "user-settings/:uid",
+    path: "user-settings",
     loadComponent: () =>
       import("./modules/user/pages/user-settings/user-settings.page").then(
         (m) => m.UserSettingsPage,

--- a/src/app/core/services/firestore.service.ts
+++ b/src/app/core/services/firestore.service.ts
@@ -369,6 +369,95 @@ export class FirestoreService {
   }
 
   /**
+   * Searches for documents in a collection based on a name field.
+   *
+   * @param {string} collectionName - Name of the collection.
+   * @param {string} searchTerm - Term to search for.
+   * @param {string} userId - Current user Id.
+   * @returns {Promise<DocumentData[] | null>} - Returns an array of documents that match the search term, otherwise null.
+   */
+  searchUserByName(
+    collectionName: string,
+    searchTerm: string,
+    userId: string | undefined,
+  ): Promise<DocumentData[] | null> {
+    if (!userId) {
+      throw new Error("User ID must be provided");
+    }
+    return getDocs(
+      query(
+        collection(this.firestore, collectionName),
+        or(
+          // query as-is:
+          and(
+            where("name", ">=", searchTerm),
+            where("name", "<=", searchTerm + "\uf8ff"),
+            where("privacySetting", "==", "public"),
+          ),
+          and(
+            where("name", ">=", searchTerm),
+            where("name", "<=", searchTerm + "\uf8ff"),
+            where("privacySetting", "==", "friends-only"),
+            where("friends", "array-contains", userId),
+          ),
+          // capitalize first letter:
+          and(
+            where(
+              "name",
+              ">=",
+              searchTerm.charAt(0).toUpperCase() + searchTerm.slice(1),
+            ),
+            where(
+              "name",
+              "<=",
+              searchTerm.charAt(0).toUpperCase() +
+                searchTerm.slice(1) +
+                "\uf8ff",
+            ),
+            where("privacySetting", "==", "public"),
+          ),
+          and(
+            where(
+              "name",
+              ">=",
+              searchTerm.charAt(0).toUpperCase() + searchTerm.slice(1),
+            ),
+            where(
+              "name",
+              "<=",
+              searchTerm.charAt(0).toUpperCase() +
+                searchTerm.slice(1) +
+                "\uf8ff",
+            ),
+            where("privacySetting", "==", "friends-only"),
+            where("friends", "array-contains", userId),
+          ),
+          // lowercase:
+          and(
+            where("name", ">=", searchTerm.toLowerCase()),
+            where("name", "<=", searchTerm.toLowerCase() + "\uf8ff"),
+            where("privacySetting", "==", "public"),
+          ),
+          and(
+            where("name", ">=", searchTerm.toLowerCase()),
+            where("name", "<=", searchTerm.toLowerCase() + "\uf8ff"),
+            where("privacySetting", "==", "friends-only"),
+            where("friends", "array-contains", userId),
+          ),
+        ),
+      ),
+    )
+      .then((querySnapshot) => {
+        return this.processFirebaseData(querySnapshot);
+      })
+      .catch((error) => {
+        console.error("Error retrieving collection: ", error);
+        this.errorHandler.handleFirebaseAuthError(error);
+        return [];
+      });
+  }
+
+  /**
    * Retrieves documents from a collection where the sender or receiver ID matches the provided ID.
    *
    * @param {string} collectionName - Name of the collection.

--- a/src/app/core/services/store.service.ts
+++ b/src/app/core/services/store.service.ts
@@ -36,6 +36,9 @@ import {
  * Service to manage the state of the application.
  */
 export class StoreService {
+  updatePrivacySetting(selectedPrivacySetting: string) {
+    throw new Error("Method not implemented.");
+  }
   /**
    * Subscription to the Firestore collections.
    */

--- a/src/app/core/services/store.service.ts
+++ b/src/app/core/services/store.service.ts
@@ -211,13 +211,29 @@ export class StoreService {
    * @param {string} name - The name to search for.
    */
   searchDocsByName(collectionName: string, name: string): void {
-    this.firestoreService.searchByName(collectionName, name).then((docs) => {
-      if (docs) {
-        docs.forEach((doc) => {
-          this.addDocToState(collectionName, doc as Partial<any>);
+    if (collectionName === "users") {
+      this.firestoreService
+        .searchUserByName(
+          collectionName,
+          name,
+          this.authStoreService.getCurrentUser()?.uid,
+        )
+        .then((docs) => {
+          if (docs) {
+            docs.forEach((doc) => {
+              this.addDocToState(collectionName, doc as Partial<any>);
+            });
+          }
         });
-      }
-    });
+    } else {
+      this.firestoreService.searchByName(collectionName, name).then((docs) => {
+        if (docs) {
+          docs.forEach((doc) => {
+            this.addDocToState(collectionName, doc as Partial<any>);
+          });
+        }
+      });
+    }
   }
 
   /**

--- a/src/app/models/user.model.ts
+++ b/src/app/models/user.model.ts
@@ -51,5 +51,6 @@ export interface AppUser {
   phoneCountryCode: string; // Phone country code (e.g. 1 for US)
   phoneNumber: string; // Phone number (e.g. 1234567890)
   phoneType: string; // Phone type (mobile, landline, etc.)
+  privacySetting: "Public" | "Friends-only" | "Private"; // Privacy setting
   // Other properties...
 }

--- a/src/app/models/user.model.ts
+++ b/src/app/models/user.model.ts
@@ -51,6 +51,6 @@ export interface AppUser {
   phoneCountryCode: string; // Phone country code (e.g. 1 for US)
   phoneNumber: string; // Phone number (e.g. 1234567890)
   phoneType: string; // Phone type (mobile, landline, etc.)
-  privacySetting: "Public" | "Friends-only" | "Private"; // Privacy setting
+  privacySetting: "public" | "friends-only" | "private"; // Privacy setting
   // Other properties...
 }

--- a/src/app/modules/user/pages/user-settings/components/settings/settings.component.html
+++ b/src/app/modules/user/pages/user-settings/components/settings/settings.component.html
@@ -1,0 +1,40 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Settings</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <ion-card>
+    <form [formGroup]="settingsForm">
+      <ion-list>
+        <ion-item>
+          <ion-label>Privacy Settings</ion-label>
+          <ion-select formControlName="privacySetting">
+            <ion-select-option value="Public">Public</ion-select-option>
+            <ion-select-option value="Friends-only"
+              >Friends-only</ion-select-option
+            >
+            <ion-select-option value="Private">Private</ion-select-option>
+          </ion-select>
+        </ion-item>
+        <ion-item>
+          <ion-label>Language</ion-label>
+          <ion-select
+            formControlName="language"
+            (ionChange)="onLanguageChange($event)"
+          >
+            <ion-select-option
+              *ngFor="let lang of languageList"
+              [value]="lang.code"
+              >{{ lang.text }}</ion-select-option
+            >
+          </ion-select>
+        </ion-item>
+      </ion-list>
+      <ion-button expand="full" (click)="updateSetting()"
+        >Save Changes</ion-button
+      >
+    </form>
+  </ion-card>
+</ion-content>

--- a/src/app/modules/user/pages/user-settings/components/settings/settings.component.html
+++ b/src/app/modules/user/pages/user-settings/components/settings/settings.component.html
@@ -1,3 +1,22 @@
+<!--
+Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+Copyright (C) 2023  ASCENDynamics NFP
+
+This file is part of Nonprofit Social Networking Platform.
+
+Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+-->
 <ion-header>
   <ion-toolbar>
     <ion-title>Settings</ion-title>

--- a/src/app/modules/user/pages/user-settings/components/settings/settings.component.html
+++ b/src/app/modules/user/pages/user-settings/components/settings/settings.component.html
@@ -11,11 +11,11 @@
         <ion-item>
           <ion-label>Privacy Settings</ion-label>
           <ion-select formControlName="privacySetting">
-            <ion-select-option value="Public">Public</ion-select-option>
-            <ion-select-option value="Friends-only"
+            <ion-select-option value="public">Public</ion-select-option>
+            <ion-select-option value="friends-only"
               >Friends-only</ion-select-option
             >
-            <ion-select-option value="Private">Private</ion-select-option>
+            <ion-select-option value="private">Private</ion-select-option>
           </ion-select>
         </ion-item>
         <ion-item>

--- a/src/app/modules/user/pages/user-settings/components/settings/settings.component.scss
+++ b/src/app/modules/user/pages/user-settings/components/settings/settings.component.scss
@@ -1,0 +1,19 @@
+/***********************************************************************************************
+* Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+* Copyright (C) 2023  ASCENDynamics NFP
+*
+* This file is part of Nonprofit Social Networking Platform.
+*
+* Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+
+* You should have received a copy of the GNU Affero General Public License
+* along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+***********************************************************************************************/

--- a/src/app/modules/user/pages/user-settings/components/settings/settings.component.spec.ts
+++ b/src/app/modules/user/pages/user-settings/components/settings/settings.component.spec.ts
@@ -1,3 +1,22 @@
+/***********************************************************************************************
+* Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+* Copyright (C) 2023  ASCENDynamics NFP
+*
+* This file is part of Nonprofit Social Networking Platform.
+*
+* Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+
+* You should have received a copy of the GNU Affero General Public License
+* along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+***********************************************************************************************/
 import {ComponentFixture, TestBed, waitForAsync} from "@angular/core/testing";
 import {IonicModule} from "@ionic/angular";
 import {SettingsComponent} from "./settings.component";

--- a/src/app/modules/user/pages/user-settings/components/settings/settings.component.spec.ts
+++ b/src/app/modules/user/pages/user-settings/components/settings/settings.component.spec.ts
@@ -1,0 +1,51 @@
+import {ComponentFixture, TestBed, waitForAsync} from "@angular/core/testing";
+import {IonicModule} from "@ionic/angular";
+import {SettingsComponent} from "./settings.component";
+import {ActivatedRoute} from "@angular/router";
+import {ReactiveFormsModule} from "@angular/forms";
+import {TranslateModule} from "@ngx-translate/core";
+import {StoreService} from "../../../../../../core/services/store.service";
+import {of} from "rxjs";
+
+class MockStoreService {
+  // Mock the methods and properties used by the component
+  users$ = of([]); // You'll need to import 'of' from 'rxjs'
+  updateDoc() {}
+}
+
+describe("SettingsComponent", () => {
+  let component: SettingsComponent;
+  let fixture: ComponentFixture<SettingsComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [], // Include the component under test
+      imports: [
+        IonicModule.forRoot(),
+        ReactiveFormsModule,
+        TranslateModule.forRoot(), // Use forRoot() for testing
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: {
+                get: () => "123", // provide your mock value here
+              },
+            },
+          },
+        },
+        {provide: StoreService, useClass: MockStoreService}, // Mock the StoreService
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SettingsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/user/pages/user-settings/components/settings/settings.component.ts
+++ b/src/app/modules/user/pages/user-settings/components/settings/settings.component.ts
@@ -34,7 +34,7 @@ export class SettingsComponent {
   private userSubscription?: Subscription;
 
   settingsForm: FormGroup = new FormGroup({
-    privacySetting: new FormControl("Public"),
+    privacySetting: new FormControl("public"),
     language: new FormControl("en"),
   });
 

--- a/src/app/modules/user/pages/user-settings/components/settings/settings.component.ts
+++ b/src/app/modules/user/pages/user-settings/components/settings/settings.component.ts
@@ -1,0 +1,85 @@
+import {Component, EventEmitter, Output} from "@angular/core";
+import {CommonModule} from "@angular/common";
+import {
+  FormControl,
+  FormGroup,
+  FormsModule,
+  ReactiveFormsModule,
+} from "@angular/forms";
+import {IonicModule} from "@ionic/angular";
+import {TranslateModule, TranslateService} from "@ngx-translate/core";
+import {Subscription} from "rxjs";
+import {StoreService} from "../../../../../../core/services/store.service";
+import {AppUser} from "../../../../../../models/user.model";
+import {ActivatedRoute, RouterModule} from "@angular/router";
+
+@Component({
+  selector: "app-settings",
+  templateUrl: "./settings.component.html",
+  styleUrls: ["./settings.component.scss"],
+  standalone: true,
+  imports: [
+    IonicModule,
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    RouterModule,
+    TranslateModule,
+  ],
+})
+export class SettingsComponent {
+  @Output() languageChange = new EventEmitter<string>();
+  private user?: Partial<AppUser> | null;
+  private userId?: string | null;
+  private userSubscription?: Subscription;
+
+  settingsForm: FormGroup = new FormGroup({
+    privacySetting: new FormControl("Public"),
+    language: new FormControl("en"),
+  });
+
+  languageList = [
+    {code: "en", name: "english", text: "English"},
+    {code: "fr", name: "french", text: "Français"},
+  ];
+
+  constructor(
+    private activatedRoute: ActivatedRoute,
+    private storeService: StoreService,
+    private translateService: TranslateService,
+  ) {
+    this.userId = this.activatedRoute.snapshot.paramMap.get("userId");
+  }
+
+  ionViewWillEnter() {
+    this.userSubscription = this.storeService.users$.subscribe((users) => {
+      this.user = users.find((u) => u.id === this.userId);
+      if (this.user) {
+        this.settingsForm.setValue({
+          privacySetting: this.user.privacySetting,
+          language: this.user.language,
+        });
+      }
+    });
+  }
+
+  ionViewWillLeave() {
+    this.userSubscription?.unsubscribe();
+  }
+
+  onLanguageChange(event: any) {
+    let lang = this.settingsForm.get("language")?.value;
+    this.translateService.use(lang);
+    this.languageChange.emit(lang);
+  }
+
+  updateSetting() {
+    if (this.userId) {
+      this.storeService.updateDoc("users", {
+        id: this.userId,
+        privacySetting: this.settingsForm.get("privacySetting")?.value,
+        language: this.settingsForm.get("language")?.value,
+      });
+    }
+  }
+}

--- a/src/app/modules/user/pages/user-settings/components/settings/settings.component.ts
+++ b/src/app/modules/user/pages/user-settings/components/settings/settings.component.ts
@@ -1,3 +1,22 @@
+/***********************************************************************************************
+* Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+* Copyright (C) 2023  ASCENDynamics NFP
+*
+* This file is part of Nonprofit Social Networking Platform.
+*
+* Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+
+* Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Affero General Public License for more details.
+
+* You should have received a copy of the GNU Affero General Public License
+* along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+***********************************************************************************************/
 import {Component, EventEmitter, Input, OnChanges, Output} from "@angular/core";
 import {CommonModule} from "@angular/common";
 import {FormBuilder, ReactiveFormsModule, Validators} from "@angular/forms";

--- a/src/app/modules/user/pages/user-settings/user-settings.page.html
+++ b/src/app/modules/user/pages/user-settings/user-settings.page.html
@@ -32,5 +32,5 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
       <ion-title size="large">User Settings</ion-title>
     </ion-toolbar>
   </ion-header>
-  <app-settings></app-settings>
+  <app-settings *ngIf="user" [authUser]="authUser" [user]="user"></app-settings>
 </ion-content>

--- a/src/app/modules/user/pages/user-settings/user-settings.page.html
+++ b/src/app/modules/user/pages/user-settings/user-settings.page.html
@@ -32,16 +32,5 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
       <ion-title size="large">User Settings</ion-title>
     </ion-toolbar>
   </ion-header>
-  <ion-list>
-    <ion-item>
-      <ion-card style="width: 100% !important">
-        <ion-card-header>
-          <ion-card-title>POC: Language Selector</ion-card-title>
-        </ion-card-header>
-        <ion-item>
-          <app-language-selector></app-language-selector>
-        </ion-item>
-      </ion-card>
-    </ion-item>
-  </ion-list>
+  <app-settings></app-settings>
 </ion-content>

--- a/src/app/modules/user/pages/user-settings/user-settings.page.spec.ts
+++ b/src/app/modules/user/pages/user-settings/user-settings.page.spec.ts
@@ -27,10 +27,15 @@ import {
 import {HttpClientTestingModule} from "@angular/common/http/testing";
 import {HttpClient} from "@angular/common/http";
 import {createTranslateLoader} from "../../../../app.component.spec";
-import {SettingsComponent} from "./components/settings/settings.component";
 import {ActivatedRoute} from "@angular/router";
 import {IonicModule} from "@ionic/angular";
 import {AuthStoreService} from "../../../../core/services/auth-store.service";
+import {StoreService} from "../../../../core/services/store.service";
+
+const mockStoreService = {
+  loadInitialData: jasmine.createSpy("loadInitialData"),
+  // ... other methods and properties you want to mock
+};
 
 describe("UserSettingsPage", () => {
   let component: UserSettingsPage;
@@ -60,6 +65,7 @@ describe("UserSettingsPage", () => {
       providers: [
         TranslateService,
         {provide: AuthStoreService, useValue: mockAuthStoreService}, // Use the mock service
+        {provide: StoreService, useValue: mockStoreService},
         {
           provide: ActivatedRoute,
           useValue: {

--- a/src/app/modules/user/pages/user-settings/user-settings.page.spec.ts
+++ b/src/app/modules/user/pages/user-settings/user-settings.page.spec.ts
@@ -17,7 +17,7 @@
 * You should have received a copy of the GNU Affero General Public License
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
-import {ComponentFixture, TestBed} from "@angular/core/testing";
+import {ComponentFixture, TestBed, waitForAsync} from "@angular/core/testing";
 import {UserSettingsPage} from "./user-settings.page";
 import {
   TranslateService,
@@ -27,17 +27,27 @@ import {
 import {HttpClientTestingModule} from "@angular/common/http/testing";
 import {HttpClient} from "@angular/common/http";
 import {createTranslateLoader} from "../../../../app.component.spec";
-import {LanguageSelectorComponent} from "../../components/language-selector/language-selector.component";
+import {SettingsComponent} from "./components/settings/settings.component";
+import {ActivatedRoute} from "@angular/router";
+import {IonicModule} from "@ionic/angular";
+import {AuthStoreService} from "../../../../core/services/auth-store.service";
 
 describe("UserSettingsPage", () => {
   let component: UserSettingsPage;
   let fixture: ComponentFixture<UserSettingsPage>;
 
-  beforeEach(async () => {
+  // Mock the AuthStoreService
+  const mockAuthStoreService = {
+    getCurrentUser: jasmine.createSpy("getCurrentUser").and.returnValue({
+      /* mock user data */
+    }),
+  };
+
+  beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      declarations: [],
       imports: [
         HttpClientTestingModule,
-        LanguageSelectorComponent,
         TranslateModule.forRoot({
           loader: {
             provide: TranslateLoader,
@@ -45,13 +55,28 @@ describe("UserSettingsPage", () => {
             deps: [HttpClient],
           },
         }),
+        IonicModule, // You might need this if your component uses Ionic components
       ],
-      providers: [TranslateService],
+      providers: [
+        TranslateService,
+        {provide: AuthStoreService, useValue: mockAuthStoreService}, // Use the mock service
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: {
+              paramMap: {
+                get: () => "123",
+              },
+            },
+          },
+        },
+      ],
     }).compileComponents();
+
     fixture = TestBed.createComponent(UserSettingsPage);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+  }));
 
   it("should create", () => {
     expect(component).toBeTruthy();

--- a/src/app/modules/user/pages/user-settings/user-settings.page.spec.ts
+++ b/src/app/modules/user/pages/user-settings/user-settings.page.spec.ts
@@ -34,6 +34,7 @@ import {StoreService} from "../../../../core/services/store.service";
 
 const mockStoreService = {
   loadInitialData: jasmine.createSpy("loadInitialData"),
+  getCollection: jasmine.createSpy("getCollection"),
   // ... other methods and properties you want to mock
 };
 

--- a/src/app/modules/user/pages/user-settings/user-settings.page.ts
+++ b/src/app/modules/user/pages/user-settings/user-settings.page.ts
@@ -23,7 +23,7 @@ import {FormsModule} from "@angular/forms";
 import {IonicModule} from "@ionic/angular";
 
 import {TranslateModule} from "@ngx-translate/core";
-import {LanguageSelectorComponent} from "../../components/language-selector/language-selector.component";
+import {SettingsComponent} from "./components/settings/settings.component";
 import {AuthStoreService} from "../../../../core/services/auth-store.service";
 
 @Component({
@@ -36,7 +36,7 @@ import {AuthStoreService} from "../../../../core/services/auth-store.service";
     CommonModule,
     FormsModule,
     TranslateModule,
-    LanguageSelectorComponent,
+    SettingsComponent,
   ],
 })
 export class UserSettingsPage {

--- a/src/app/modules/user/pages/user-settings/user-settings.page.ts
+++ b/src/app/modules/user/pages/user-settings/user-settings.page.ts
@@ -22,28 +22,42 @@ import {CommonModule} from "@angular/common";
 import {FormsModule} from "@angular/forms";
 import {IonicModule} from "@ionic/angular";
 
-import {TranslateModule} from "@ngx-translate/core";
 import {SettingsComponent} from "./components/settings/settings.component";
 import {AuthStoreService} from "../../../../core/services/auth-store.service";
+import {Subscription} from "rxjs";
+import {StoreService} from "../../../../core/services/store.service";
+import {AppUser} from "../../../../models/user.model";
 
 @Component({
   selector: "app-user-settings",
   templateUrl: "./user-settings.page.html",
   styleUrls: ["./user-settings.page.scss"],
   standalone: true,
-  imports: [
-    IonicModule,
-    CommonModule,
-    FormsModule,
-    TranslateModule,
-    SettingsComponent,
-  ],
+  imports: [IonicModule, CommonModule, FormsModule, SettingsComponent],
 })
 export class UserSettingsPage {
-  user = this.authStoreService.getCurrentUser();
-  constructor(private authStoreService: AuthStoreService) {}
+  private userSubscription?: Subscription;
+  authUser = this.authStoreService.getCurrentUser();
+  user?: Partial<AppUser> | null;
+  constructor(
+    private authStoreService: AuthStoreService,
+    private storeService: StoreService,
+  ) {
+    this.authUser = this.authStoreService.getCurrentUser();
+  }
 
-  ionViewWillEnter() {}
+  ionViewWillEnter() {
+    this.userSubscription = this.storeService.users$.subscribe((users) => {
+      this.user = users.find((u) => u.id === this.authUser?.uid);
+    });
+    if (!this.user) {
+      this.user = this.storeService
+        .getCollection("users")
+        .find((u) => u["id"] === this.authUser?.uid);
+    }
+  }
 
-  ionViewWillLeave() {}
+  ionViewWillLeave() {
+    this.userSubscription?.unsubscribe();
+  }
 }

--- a/src/app/shared/components/menu/menu.component.ts
+++ b/src/app/shared/components/menu/menu.component.ts
@@ -180,7 +180,7 @@ export class MenuComponent implements OnInit, OnDestroy {
         buttonText: "",
         hasButton: false,
         title: "Settings",
-        url: `user-settings/${this.user?.uid}`,
+        url: `user-settings`,
         icon: "settings",
         onclick: null,
       },


### PR DESCRIPTION
## Description

Added `privacySetting` property.  
Updated Firestore rules.
Updated `users` search by name query.

Fixes # (issue)
#73 
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [ ] Navigate to `Settings`, select `private` or `friends-only`.  Navigate away, and back the privacy settings should remain.
- [ ] Login to a new account, if user is private, you should not be able to view them in search or see their information on their profile.
- [ ] If user is `friends-only`, you should only be able to view their profile or search them once you're both friends.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
