### PR TITLE
Centralize segment styles

### DIFF
--- a/src/app/modules/account/relatedListings/pages/listings-list/listings-list.page.scss
+++ b/src/app/modules/account/relatedListings/pages/listings-list/listings-list.page.scss
@@ -17,35 +17,4 @@
 * You should have received a copy of the GNU Affero General Public License
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
-ion-segment {
-  --padding-top: 0;
-  --padding-bottom: 0;
-  --padding-start: 0;
-  --padding-end: 0;
-  --indicator-height: 2px;
-  overflow-x: auto;
-}
-
-ion-segment-button {
-  --padding: 6px 8px;
-  --min-width: auto;
-  flex: 0 0 auto;
-}
-
-ion-segment-button ion-icon {
-  font-size: 16px;
-}
-
-ion-segment-button ion-label {
-  font-size: 12px;
-}
-
-@media (max-width: 576px) {
-  ion-segment-button {
-    --padding: 4px 6px;
-  }
-
-  ion-segment-button ion-label {
-    display: none; /* Hide labels on very small screens */
-  }
-}
+@import '../../../../../../styles/segment';

--- a/src/app/modules/listing/pages/listings/listings.page.scss
+++ b/src/app/modules/listing/pages/listings/listings.page.scss
@@ -17,44 +17,4 @@
 * You should have received a copy of the GNU Affero General Public License
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
-ion-segment {
-  --padding-top: 0;
-  --padding-bottom: 0;
-  --padding-start: 0;
-  --padding-end: 0;
-  --indicator-height: 2px;
-  overflow-x: auto;
-}
-
-ion-segment-button {
-  --padding: 6px 8px;
-  --min-width: auto;
-  flex: 0 0 auto;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-ion-segment-button ion-icon {
-  font-size: 20px;
-  margin-bottom: 4px;
-}
-
-ion-segment-button ion-label {
-  font-size: 12px;
-  margin: 0;
-}
-
-@media (max-width: 576px) {
-  ion-segment-button {
-    --padding: 4px 6px;
-  }
-
-  ion-segment-button ion-label {
-    display: none;
-  }
-
-  ion-segment-button ion-icon {
-    margin-bottom: 0;
-  }
-}
+@import '../../../../../styles/segment';

--- a/src/global.scss
+++ b/src/global.scss
@@ -44,6 +44,7 @@
 @import "@ionic/angular/css/text-alignment.css";
 @import "@ionic/angular/css/text-transformation.css";
 @import "@ionic/angular/css/flex-utils.css";
+@import "./styles/segment";
 
 /* Theme variables */
 

--- a/src/styles/_segment.scss
+++ b/src/styles/_segment.scss
@@ -1,0 +1,41 @@
+ion-segment {
+  --padding-top: 0;
+  --padding-bottom: 0;
+  --padding-start: 0;
+  --padding-end: 0;
+  --indicator-height: 2px;
+  overflow-x: auto;
+}
+
+ion-segment-button {
+  --padding: 6px 8px;
+  --min-width: auto;
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+ion-segment-button ion-icon {
+  font-size: 20px;
+  margin-bottom: 4px;
+}
+
+ion-segment-button ion-label {
+  font-size: 12px;
+  margin: 0;
+}
+
+@media (max-width: 576px) {
+  ion-segment-button {
+    --padding: 4px 6px;
+  }
+
+  ion-segment-button ion-label {
+    display: none;
+  }
+
+  ion-segment-button ion-icon {
+    margin-bottom: 0;
+  }
+}


### PR DESCRIPTION
## Summary
- create a shared SCSS partial for segment styling
- import the shared styles into listing pages

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa7706824832683bb80fb6c78289f