### PR TITLE
Add PR domain cleanup workflow

### DIFF
--- a/.github/scripts/removeAuthorizedDomain.js
+++ b/.github/scripts/removeAuthorizedDomain.js
@@ -1,0 +1,48 @@
+const { google } = require('googleapis');
+
+const serviceAccount = JSON.parse(process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON);
+const projectId = process.env.FIREBASE_PROJECT_ID;
+const previewDomain = process.env.PREVIEW_DOMAIN;
+
+async function removeAuthorizedDomain() {
+  try {
+    const auth = new google.auth.GoogleAuth({
+      credentials: serviceAccount,
+      scopes: ['https://www.googleapis.com/auth/identitytoolkit'],
+    });
+
+    const authClient = await auth.getClient();
+
+    const identityToolkit = google.identitytoolkit({
+      version: 'v3',
+      auth: authClient,
+    });
+
+    const configRes = await identityToolkit.projects.getConfig({
+      name: `projects/${projectId}/config`,
+    });
+
+    let currentDomains = configRes.data.authorizedDomains || [];
+
+    if (currentDomains.includes(previewDomain)) {
+      currentDomains = currentDomains.filter((d) => d !== previewDomain);
+
+      await identityToolkit.projects.updateConfig({
+        name: `projects/${projectId}/config`,
+        updateMask: 'authorizedDomains',
+        requestBody: {
+          authorizedDomains: currentDomains,
+        },
+      });
+
+      console.log(`Removed ${previewDomain} from authorized domains.`);
+    } else {
+      console.log(`${previewDomain} not found in authorized domains.`);
+    }
+  } catch (error) {
+    console.error('Error removing authorized domain:', error);
+    process.exit(1);
+  }
+}
+
+removeAuthorizedDomain();

--- a/.github/workflows/pr-domain-cleanup.yml
+++ b/.github/workflows/pr-domain-cleanup.yml
@@ -1,0 +1,21 @@
+name: Remove PR Preview Domain
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Remove authorized preview domain
+        run: node .github/scripts/removeAuthorizedDomain.js
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS_JSON: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_ASCENDCOOPPLATFORM_DEV }}
+          FIREBASE_PROJECT_ID: ${{ secrets.DEV_FIREBASE_PROJECT_ID }}
+          PREVIEW_DOMAIN: pr-${{ github.event.pull_request.number }}--ascendcoopplatform-dev.web.app


### PR DESCRIPTION
## Summary
- add a script that removes a preview domain from Firebase auth
- clean up authorized domain when a PR is closed

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686ad368c1108326b24c1599c6e101a6