### PR TITLE
Add husky pre-commit hook

### DIFF
--- a/.husky/_/.gitignore
+++ b/.husky/_/.gitignore
@@ -1,0 +1,3 @@
+*
+!husky.sh
+!.gitignore

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env sh
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    if [ "$HUSKY_DEBUG" = "1" ]; then
+      echo "husky (debug) - $1"
+    fi
+  }
+
+  readonly hook_name="$(basename -- "$0")"
+  debug "starting $hook_name..."
+
+  if [ "$HUSKY" = "0" ]; then
+    debug "HUSKY env variable is set to 0, skipping hook"
+    exit 0
+  fi
+
+  if [ -f ~/.huskyrc ]; then
+    debug "sourcing ~/.huskyrc"
+    . ~/.huskyrc
+  fi
+
+  readonly husky_skip_init=1
+  export husky_skip_init
+  sh -e "$0" "$@"
+  exitCode="$?"
+
+  if [ $exitCode != 0 ]; then
+    echo "husky - $hook_name hook exited with code $exitCode (error)"
+  fi
+
+  if [ $exitCode = 127 ]; then
+    echo "husky - command not found in PATH=$PATH"
+  fi
+
+  exit $exitCode
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ By participating in this project, you are expected to uphold our [Code of Conduc
 
    This will allow you to pull changes from the main repository and keep your fork up-to-date.
 
-4. **Set up the development environment**: Follow the instructions in the [README.md](README.md) file to set up your local development environment.
+4. **Set up the development environment**: Follow the instructions in the [README.md](README.md) file to set up your local development environment. Installing dependencies (`npm install`) automatically sets up Git hooks. If you don't see them, run `npm run prepare`.
 
 ## Contributing Code
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ We look forward to your contributions and engaging discussions!
 1. Install Node.js, npm, Ionic CLI, and Angular CLI on your development machine.
 2. Clone this repository: `git clone https://github.com/ASCENDynamics-NFP/AscendCoopPlatform.git`
 3. Change to the project directory: `cd AscendCoopPlatform`
-4. Install dependencies: `npm install`
+4. Install dependencies: `npm install` (Git hooks are installed automatically). If you don't see them, run `npm run prepare`.
 5. Create `.env.development` (and optionally `.env.production`) with your Firebase credentials. The file should define variables such as `FIREBASE_API_KEY`, `FIREBASE_AUTH_DOMAIN`, `FIREBASE_DATABASE_URL`, `FIREBASE_PROJECT_ID`, `FIREBASE_STORAGE_BUCKET`, `FIREBASE_MESSAGING_SENDER_ID`, `FIREBASE_APP_ID`, `FIREBASE_MEASUREMENT_ID`, and `FIREBASE_API_URL`.
 6. Run `npm run generate-env:dev` (or `NODE_ENV=development node generate-env.js`) to generate `src/environments/environment.ts`. Use `npm run generate-env:prod` for production.
 7. Run the development server: `ionic serve`

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "npm run generate-env:dev && ng serve",
     "start:prod": "npm run generate-env:prod && ng serve --configuration production",
     "format": "prettier --write .",
+    "prepare": "husky install",
     "ng": "ng",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",


### PR DESCRIPTION
## Summary
- set up a `.husky` directory with a pre-commit hook running `npx lint-staged`
- mention running `npm run prepare` if hooks aren't installed automatically
- clarify that Git hooks are installed automatically via `npm install`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871d64a225883269f4f350636f49d81