### PR TITLE
Refactor reducers with entity adapter

### DIFF
--- a/src/app/modules/account/pages/details/details.page.ts
+++ b/src/app/modules/account/pages/details/details.page.ts
@@ -46,7 +46,7 @@ export class DetailsPage implements OnInit, ViewWillEnter {
   @ViewChild(IonContent, {static: false}) content!: IonContent;
   public accountId: string | null = null;
   authUser$!: Observable<AuthUser | null>;
-  account$!: Observable<Account | null>;
+  account$!: Observable<Account | undefined>;
   private subscription: Subscription | null = null;
   relatedAccounts$!: Observable<RelatedAccount[]>;
   relatedListings$!: Observable<RelatedListing[]>;

--- a/src/app/modules/listing/relatedAccount/pages/apply/apply.page.ts
+++ b/src/app/modules/listing/relatedAccount/pages/apply/apply.page.ts
@@ -45,7 +45,7 @@ export class ApplyPage implements OnInit {
   coverLetterFile: File | null = null;
   authUser$: Observable<AuthUser | null>;
   listingId?: string;
-  listing$: Observable<Listing>;
+  listing$: Observable<Listing | undefined>;
   @ViewChild("resumeInput") resumeInput!: ElementRef<HTMLInputElement>;
   @ViewChild("coverLetterInput")
   coverLetterInput!: ElementRef<HTMLInputElement>;

--- a/src/app/state/reducers/account.reducer.ts
+++ b/src/app/state/reducers/account.reducer.ts
@@ -20,12 +20,15 @@
 // src/app/state/reducers/account.reducer.ts
 
 import {createReducer, on} from "@ngrx/store";
+import {createEntityAdapter, EntityAdapter, EntityState} from "@ngrx/entity";
 import * as AccountActions from "../actions/account.actions";
 import {Account, RelatedAccount} from "../../models/account.model";
 import {RelatedListing} from "../../models/related-listing.model";
 
-export interface AccountState {
-  entities: {[id: string]: Account};
+export const accountAdapter: EntityAdapter<Account> =
+  createEntityAdapter<Account>({selectId: (account) => account.id});
+
+export interface AccountState extends EntityState<Account> {
   relatedAccounts: {[accountId: string]: RelatedAccount[]};
   relatedListings: {[accountId: string]: RelatedListing[]};
   selectedAccountId: string | null;
@@ -38,8 +41,7 @@ export interface AccountState {
   relatedListingsLastUpdated: {[accountId: string]: number | null};
 }
 
-export const initialState: AccountState = {
-  entities: {},
+export const initialState: AccountState = accountAdapter.getInitialState({
   relatedAccounts: {},
   relatedListings: {},
   selectedAccountId: null,
@@ -49,7 +51,7 @@ export const initialState: AccountState = {
   accountsLastUpdated: null,
   relatedAccountsLastUpdated: {},
   relatedListingsLastUpdated: {},
-};
+});
 
 export const accountReducer = createReducer(
   initialState,
@@ -65,18 +67,13 @@ export const accountReducer = createReducer(
     loading: true,
     error: null,
   })),
-  on(AccountActions.loadAccountsSuccess, (state, {accounts}) => ({
-    ...state,
-    entities: accounts.reduce(
-      (entities: {[id: string]: Account}, account) => ({
-        ...entities,
-        [account.id]: account,
-      }),
-      {},
-    ),
-    loading: false,
-    accountsLastUpdated: Date.now(),
-  })),
+  on(AccountActions.loadAccountsSuccess, (state, {accounts}) =>
+    accountAdapter.setAll(accounts, {
+      ...state,
+      loading: false,
+      accountsLastUpdated: Date.now(),
+    }),
+  ),
   on(AccountActions.loadAccountsFailure, (state, {error}) => ({
     ...state,
     loading: false,
@@ -89,16 +86,14 @@ export const accountReducer = createReducer(
     loading: true,
     error: null,
   })),
-  on(AccountActions.loadAccountSuccess, (state, {account}) => ({
-    ...state,
-    entities: {
-      ...state.entities,
-      [account.id]: account,
-    },
-    selectedAccountId: account.id,
-    loading: false,
-    error: null,
-  })),
+  on(AccountActions.loadAccountSuccess, (state, {account}) =>
+    accountAdapter.upsertOne(account, {
+      ...state,
+      selectedAccountId: account.id,
+      loading: false,
+      error: null,
+    }),
+  ),
   on(AccountActions.loadAccountFailure, (state, {error}) => ({
     ...state,
     loading: false,
@@ -106,34 +101,23 @@ export const accountReducer = createReducer(
   })),
 
   // Create Account
-  on(AccountActions.createAccountSuccess, (state, {account}) => ({
-    ...state,
-    entities: {
-      ...state.entities,
-      [account.id]: account,
-    },
-  })),
+  on(AccountActions.createAccountSuccess, (state, {account}) =>
+    accountAdapter.addOne(account, state),
+  ),
 
   // Update Account
-  on(AccountActions.updateAccountSuccess, (state, {account}) => ({
-    ...state,
-    entities: {
-      ...state.entities,
-      [account.id]: account,
-    },
-  })),
+  on(AccountActions.updateAccountSuccess, (state, {account}) =>
+    accountAdapter.updateOne({id: account.id, changes: account}, state),
+  ),
 
   // Delete Account
   on(AccountActions.deleteAccountSuccess, (state, {accountId}) => {
-    const {[accountId]: removedAccount, ...entities} = state.entities;
-    const {[accountId]: removedRelatedAccounts, ...relatedAccounts} =
-      state.relatedAccounts;
-    const {[accountId]: removedRelatedListings, ...relatedListings} =
-      state.relatedListings;
+    const newState = accountAdapter.removeOne(accountId, state);
+    const {[accountId]: _ra, ...relatedAccounts} = newState.relatedAccounts;
+    const {[accountId]: _rl, ...relatedListings} = newState.relatedListings;
 
     return {
-      ...state,
-      entities,
+      ...newState,
       relatedAccounts,
       relatedListings,
     };

--- a/src/app/state/reducers/listings.reducer.ts
+++ b/src/app/state/reducers/listings.reducer.ts
@@ -20,12 +20,12 @@
 // src/app/state/listings/listings.reducer.ts
 
 import {createReducer, on} from "@ngrx/store";
+import {createEntityAdapter, EntityAdapter, EntityState} from "@ngrx/entity";
 import * as ListingsActions from "../actions/listings.actions";
 import {Listing} from "../../models/listing.model";
 import {ListingRelatedAccount} from "../../models/listing-related-account.model";
 
-export interface ListingsState {
-  entities: {[id: string]: Listing}; // Dictionary of listings by ID
+export interface ListingsState extends EntityState<Listing> {
   relatedAccounts: {[listingId: string]: ListingRelatedAccount[]};
   selectedListingId: string | null; // Currently selected listing
   loading: boolean; // Indicates if a request is in progress
@@ -38,8 +38,10 @@ export interface ListingsState {
   relatedAccountsLastUpdated: {[listingId: string]: number | null};
 }
 
-const initialState: ListingsState = {
-  entities: {},
+export const listingsAdapter: EntityAdapter<Listing> =
+  createEntityAdapter<Listing>({selectId: (listing) => listing.id});
+
+const initialState: ListingsState = listingsAdapter.getInitialState({
   relatedAccounts: {},
   selectedListingId: null,
   loading: false,
@@ -49,7 +51,7 @@ const initialState: ListingsState = {
   // Timestamps for cache invalidation
   listingsLastUpdated: null,
   relatedAccountsLastUpdated: {},
-};
+});
 
 export const listingsReducer = createReducer(
   initialState,
@@ -65,18 +67,13 @@ export const listingsReducer = createReducer(
     loading: true,
     error: null,
   })),
-  on(ListingsActions.loadListingsSuccess, (state, {listings}) => ({
-    ...state,
-    entities: listings.reduce(
-      (entities, listing) => ({
-        ...entities,
-        [listing.id]: listing,
-      }),
-      {},
-    ),
-    listingsLastUpdated: Date.now(),
-    loading: false,
-  })),
+  on(ListingsActions.loadListingsSuccess, (state, {listings}) =>
+    listingsAdapter.setAll(listings, {
+      ...state,
+      listingsLastUpdated: Date.now(),
+      loading: false,
+    }),
+  ),
   on(ListingsActions.loadListingsFailure, (state, {error}) => ({
     ...state,
     loading: false,
@@ -84,17 +81,19 @@ export const listingsReducer = createReducer(
   })),
 
   // Load Listing by ID
-  on(ListingsActions.loadListingByIdSuccess, (state, {listing}) => ({
-    ...state,
-    entities: listing
-      ? {
-          ...state.entities,
-          [listing.id]: listing,
-        }
-      : state.entities,
-    selectedListingId: listing?.id || null,
-    loading: false,
-  })),
+  on(ListingsActions.loadListingByIdSuccess, (state, {listing}) =>
+    listing
+      ? listingsAdapter.upsertOne(listing, {
+          ...state,
+          selectedListingId: listing.id,
+          loading: false,
+        })
+      : {
+          ...state,
+          selectedListingId: null,
+          loading: false,
+        },
+  ),
   on(ListingsActions.loadListingByIdFailure, (state, {error}) => ({
     ...state,
     error,
@@ -102,15 +101,13 @@ export const listingsReducer = createReducer(
   })),
 
   // Create Listing
-  on(ListingsActions.createListingSuccess, (state, {listing}) => ({
-    ...state,
-    entities: {
-      ...state.entities,
-      [listing.id]: listing,
-    },
-    selectedListingId: listing.id,
-    loading: false,
-  })),
+  on(ListingsActions.createListingSuccess, (state, {listing}) =>
+    listingsAdapter.addOne(listing, {
+      ...state,
+      selectedListingId: listing.id,
+      loading: false,
+    }),
+  ),
   on(ListingsActions.createListingFailure, (state, {error}) => ({
     ...state,
     loading: false,
@@ -118,14 +115,15 @@ export const listingsReducer = createReducer(
   })),
 
   // Update Listing
-  on(ListingsActions.updateListingSuccess, (state, {listing}) => ({
-    ...state,
-    entities: {
-      ...state.entities,
-      [listing.id]: listing,
-    },
-    loading: false,
-  })),
+  on(ListingsActions.updateListingSuccess, (state, {listing}) =>
+    listingsAdapter.updateOne(
+      {id: listing.id, changes: listing},
+      {
+        ...state,
+        loading: false,
+      },
+    ),
+  ),
   on(ListingsActions.updateListingFailure, (state, {error}) => ({
     ...state,
     loading: false,
@@ -134,12 +132,11 @@ export const listingsReducer = createReducer(
 
   // Delete Listing
   on(ListingsActions.deleteListingSuccess, (state, {id}) => {
-    const {[id]: removed, ...entities} = state.entities;
+    const newState = listingsAdapter.removeOne(id, state);
     const selectedListingId =
-      state.selectedListingId === id ? null : state.selectedListingId;
+      newState.selectedListingId === id ? null : newState.selectedListingId;
     return {
-      ...state,
-      entities,
+      ...newState,
       selectedListingId,
     };
   }),

--- a/src/app/state/selectors/account.selectors.ts
+++ b/src/app/state/selectors/account.selectors.ts
@@ -20,7 +20,7 @@
 // src/app/state/selectors/account.selectors.ts
 
 import {createFeatureSelector, createSelector} from "@ngrx/store";
-import {AccountState} from "../reducers/account.reducer";
+import {AccountState, accountAdapter} from "../reducers/account.reducer";
 import {Account} from "../../models/account.model";
 
 // TTL Configuration
@@ -39,18 +39,26 @@ export const selectAccountState =
   createFeatureSelector<AccountState>("accounts");
 
 // Entity Selectors
+const {
+  selectAll: selectAllAccountsArray,
+  selectEntities: selectAccountEntityMap,
+} = accountAdapter.getSelectors();
+
 export const selectAccountEntities = createSelector(
   selectAccountState,
-  (state) => state.entities,
+  selectAccountEntityMap,
 );
 
 export const selectAllAccounts = createSelector(
-  selectAccountEntities,
-  (entities) => Object.values(entities),
+  selectAccountState,
+  selectAllAccountsArray,
 );
 
 export const selectAccountById = (accountId: string) =>
-  createSelector(selectAccountEntities, (entities) => entities[accountId]);
+  createSelector(
+    selectAccountEntities,
+    (entities): Account | undefined => entities[accountId],
+  );
 
 // Selected Account Selectors
 export const selectSelectedAccountId = createSelector(

--- a/src/app/state/selectors/listings.selectors.ts
+++ b/src/app/state/selectors/listings.selectors.ts
@@ -20,7 +20,8 @@
 // src/app/state/listings/listings.selectors.ts
 
 import {createFeatureSelector, createSelector} from "@ngrx/store";
-import {ListingsState} from "../reducers/listings.reducer";
+import {ListingsState, listingsAdapter} from "../reducers/listings.reducer";
+import {Listing} from "../../models/listing.model";
 
 // TTL in milliseconds (e.g., 5 minutes)
 const LISTINGS_TTL = 5 * 60 * 1000; // 5 minutes
@@ -44,24 +45,31 @@ export const selectRelatedAccountsByListingId = (listingId: string) =>
   );
 
 // Select all listings
+const {
+  selectAll: selectAllListingsArray,
+  selectEntities: selectListingEntities,
+} = listingsAdapter.getSelectors();
+
 export const selectAllListings = createSelector(
   selectListingsState,
-  (state: ListingsState) => Object.values(state.entities),
+  selectAllListingsArray,
 );
 
 // Select a specific listing by ID
 export const selectListingById = (listingId: string) =>
   createSelector(
     selectListingsState,
-    (state: ListingsState) => state.entities[listingId],
+    (state): Listing | undefined => selectListingEntities(state)[listingId],
   );
 
 // Select the currently selected listing
 export const selectSelectedListing = createSelector(
   selectListingsState,
-  (state: ListingsState) =>
+  (state) =>
     state.selectedListingId
-      ? state.entities[state.selectedListingId]
+      ? (selectListingEntities(state)[state.selectedListingId] as
+          | Listing
+          | undefined)
       : undefined,
 );
 


### PR DESCRIPTION
## Summary
- use `createEntityAdapter` in account and listings reducers
- expose adapter-based selectors
- adjust pages for updated selector types

## Testing
- `npm run test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6871f3d43c248326bdce1a9838d94d46