### PR TITLE
Remove root account effects

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -43,7 +43,6 @@ import {StoreDevtoolsModule} from "@ngrx/store-devtools";
 
 // Reducers and Effects
 import {reducers} from "./state/reducers";
-import {AccountEffects} from "./state/effects/account.effects";
 import {AuthEffects} from "./state/effects/auth.effects";
 
 // Services
@@ -102,7 +101,7 @@ export function createTranslateLoader(http: HttpClient) {
       },
     }),
     StoreModule.forRoot(reducers, {metaReducers}),
-    EffectsModule.forRoot([AuthEffects, AccountEffects]),
+    EffectsModule.forRoot([AuthEffects]),
     StoreDevtoolsModule.instrument({maxAge: 25, logOnly: !isDevMode()}),
   ],
   providers: [

--- a/src/app/state/reducers/index.ts
+++ b/src/app/state/reducers/index.ts
@@ -21,13 +21,8 @@
 
 import {ActionReducerMap} from "@ngrx/store";
 import {authReducer} from "./auth.reducer";
-import {accountReducer} from "./account.reducer";
-import {listingsReducer} from "./listings.reducer";
-import {AppState} from "../app.state";
 
-export const reducers: ActionReducerMap<AppState> = {
+export const reducers: ActionReducerMap<any> = {
   auth: authReducer,
-  accounts: accountReducer,
-  listings: listingsReducer,
-  // Other reducers...
+  // Other reducers registered in feature modules
 };

--- a/src/app/state/reducers/listings.reducer.ts
+++ b/src/app/state/reducers/listings.reducer.ts
@@ -41,7 +41,7 @@ export interface ListingsState extends EntityState<Listing> {
 export const listingsAdapter: EntityAdapter<Listing> =
   createEntityAdapter<Listing>({selectId: (listing) => listing.id});
 
-const initialState: ListingsState = listingsAdapter.getInitialState({
+export const initialState: ListingsState = listingsAdapter.getInitialState({
   relatedAccounts: {},
   selectedListingId: null,
   loading: false,

--- a/src/app/state/selectors/account.selectors.ts
+++ b/src/app/state/selectors/account.selectors.ts
@@ -20,7 +20,11 @@
 // src/app/state/selectors/account.selectors.ts
 
 import {createFeatureSelector, createSelector} from "@ngrx/store";
-import {AccountState, accountAdapter} from "../reducers/account.reducer";
+import {
+  AccountState,
+  accountAdapter,
+  initialState as accountInitialState,
+} from "../reducers/account.reducer";
 import {Account} from "@shared/models/account.model";
 
 // TTL Configuration
@@ -35,8 +39,13 @@ function isStale(lastUpdated: number | null, ttl: number): boolean {
 }
 
 // Feature Selector
-export const selectAccountState =
+const selectAccountStateUnsafe =
   createFeatureSelector<AccountState>("accounts");
+
+export const selectAccountState = createSelector(
+  selectAccountStateUnsafe,
+  (state) => state || accountInitialState,
+);
 
 // Entity Selectors
 const {

--- a/src/app/state/selectors/listings.selectors.ts
+++ b/src/app/state/selectors/listings.selectors.ts
@@ -20,7 +20,11 @@
 // src/app/state/listings/listings.selectors.ts
 
 import {createFeatureSelector, createSelector} from "@ngrx/store";
-import {ListingsState, listingsAdapter} from "../reducers/listings.reducer";
+import {
+  ListingsState,
+  listingsAdapter,
+  initialState as listingsInitialState,
+} from "../reducers/listings.reducer";
 import {Listing} from "@shared/models/listing.model";
 
 // TTL in milliseconds (e.g., 5 minutes)
@@ -34,8 +38,13 @@ function isStale(lastUpdated: number | null, ttl: number): boolean {
 }
 
 // Feature Selector
-export const selectListingsState =
+const selectListingsStateUnsafe =
   createFeatureSelector<ListingsState>("listings");
+
+export const selectListingsState = createSelector(
+  selectListingsStateUnsafe,
+  (state) => state || listingsInitialState,
+);
 
 // Selectors for related accounts
 export const selectRelatedAccountsByListingId = (listingId: string) =>


### PR DESCRIPTION
## Summary
- avoid registering accounts and listings twice in the store
- only register `AccountEffects` in the account feature

## Testing
- `npx ng build --configuration development`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_687205a67bd88326a2c250c0fd7e3fa1