### PR TITLE
Refactor Firebase admin init for functions

### DIFF
--- a/functions/src/auth/user/triggers/onCreate/index.ts
+++ b/functions/src/auth/user/triggers/onCreate/index.ts
@@ -18,14 +18,9 @@
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
 import * as functions from "firebase-functions/v1/auth";
-import * as admin from "firebase-admin";
+import {admin} from "../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
 import {Timestamp} from "firebase-admin/firestore";
-
-// Initialize Firebase Admin SDK if not already initialized
-if (!admin.apps.length) {
-  admin.initializeApp();
-}
 
 // Firestore database reference
 const db = admin.firestore();

--- a/functions/src/auth/user/triggers/onDelete/index.ts
+++ b/functions/src/auth/user/triggers/onDelete/index.ts
@@ -18,14 +18,10 @@
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
 import * as functions from "firebase-functions/v1/auth";
-import * as admin from "firebase-admin";
+import {admin} from "../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
 
 // Initialize Firebase Admin SDK if not already initialized
-if (!admin.apps.length) {
-  admin.initializeApp();
-}
-
 // Firestore database reference
 const db = admin.firestore();
 

--- a/functions/src/database/accounts/relatedAccounts/triggers/onCreate/index.ts
+++ b/functions/src/database/accounts/relatedAccounts/triggers/onCreate/index.ts
@@ -18,15 +18,12 @@
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
 import * as functions from "firebase-functions";
-import * as admin from "firebase-admin";
+import {admin} from "../../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
 import {EventContext} from "firebase-functions";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 
 // Initialize the Firebase admin SDK
-if (!admin.apps.length) {
-  admin.initializeApp();
-}
 // Reference to the Firestore database
 const db = admin.firestore();
 

--- a/functions/src/database/accounts/relatedAccounts/triggers/onDelete/index.ts
+++ b/functions/src/database/accounts/relatedAccounts/triggers/onDelete/index.ts
@@ -18,15 +18,12 @@
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
 import * as functions from "firebase-functions";
-import * as admin from "firebase-admin";
+import {admin} from "../../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
 import {EventContext} from "firebase-functions";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 
 // Initialize the Firebase admin SDK
-if (!admin.apps.length) {
-  admin.initializeApp();
-}
 // Reference to the Firestore database
 const db = admin.firestore();
 

--- a/functions/src/database/accounts/relatedAccounts/triggers/onUpdate/index.ts
+++ b/functions/src/database/accounts/relatedAccounts/triggers/onUpdate/index.ts
@@ -18,15 +18,12 @@
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
 import * as functions from "firebase-functions";
-import * as admin from "firebase-admin";
+import {admin} from "../../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
 import {Change, EventContext} from "firebase-functions";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 
 // Initialize the Firebase admin SDK
-if (!admin.apps.length) {
-  admin.initializeApp();
-}
 // Reference to the Firestore database
 const db = admin.firestore();
 

--- a/functions/src/database/accounts/relatedListings/triggers/onDelete/index.ts
+++ b/functions/src/database/accounts/relatedListings/triggers/onDelete/index.ts
@@ -20,14 +20,10 @@
 // functions/src/database/accounts/relatedListings/triggers/onDelete/index.ts
 
 import * as functions from "firebase-functions";
-import * as admin from "firebase-admin";
+import {admin} from "../../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
 import {EventContext} from "firebase-functions";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
-
-if (!admin.apps.length) {
-  admin.initializeApp();
-}
 
 const db = admin.firestore();
 

--- a/functions/src/database/accounts/triggers/onUpdate/index.ts
+++ b/functions/src/database/accounts/triggers/onUpdate/index.ts
@@ -19,16 +19,12 @@
 ***********************************************************************************************/
 
 import * as functions from "firebase-functions";
-import * as admin from "firebase-admin";
+import {admin} from "../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 import {geocodeAddress} from "../../../../utils/geocoding"; // <-- Now only importing geocodeAddress
 
 // Initialize the Firebase admin SDK
-if (!admin.apps.length) {
-  admin.initializeApp();
-}
-
 /**
  * Cloud Function triggered when a document in the `accounts` collection is updated.
  */

--- a/functions/src/database/listings/relatedAccounts/triggers/onCreate/index.ts
+++ b/functions/src/database/listings/relatedAccounts/triggers/onCreate/index.ts
@@ -20,14 +20,10 @@
 // functions/src/database/listings/relatedAccounts/triggers/onCreate/index.ts
 
 import * as functions from "firebase-functions";
-import * as admin from "firebase-admin";
+import {admin} from "../../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
 import {EventContext} from "firebase-functions";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
-
-if (!admin.apps.length) {
-  admin.initializeApp();
-}
 
 const db = admin.firestore();
 

--- a/functions/src/database/listings/relatedAccounts/triggers/onUpdate/index.ts
+++ b/functions/src/database/listings/relatedAccounts/triggers/onUpdate/index.ts
@@ -20,14 +20,10 @@
 // functions/src/database/listings/relatedAccounts/triggers/onCreate/index.ts
 
 import * as functions from "firebase-functions";
-import * as admin from "firebase-admin";
+import {admin} from "../../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
 import {EventContext} from "firebase-functions";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
-
-if (!admin.apps.length) {
-  admin.initializeApp();
-}
 
 const db = admin.firestore();
 

--- a/functions/src/database/listings/triggers/onCreate/index.ts
+++ b/functions/src/database/listings/triggers/onCreate/index.ts
@@ -19,17 +19,13 @@
 ***********************************************************************************************/
 
 import * as functions from "firebase-functions";
-import * as admin from "firebase-admin";
+import {admin} from "../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
 import {EventContext} from "firebase-functions";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 import {geocodeAddress} from "../../../../utils/geocoding"; // <-- using the same utility
 
 // Initialize the Firebase admin SDK
-if (!admin.apps.length) {
-  admin.initializeApp();
-}
-
 // Reference to the Firestore database
 const db = admin.firestore();
 

--- a/functions/src/database/listings/triggers/onDelete/index.ts
+++ b/functions/src/database/listings/triggers/onDelete/index.ts
@@ -20,14 +20,10 @@
 // functions/src/database/listings/triggers/onDelete/index.ts
 
 import * as functions from "firebase-functions";
-import * as admin from "firebase-admin";
+import {admin} from "../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
 import {EventContext} from "firebase-functions";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
-
-if (!admin.apps.length) {
-  admin.initializeApp();
-}
 
 const db = admin.firestore();
 

--- a/functions/src/database/listings/triggers/onUpdate/index.ts
+++ b/functions/src/database/listings/triggers/onUpdate/index.ts
@@ -20,15 +20,11 @@
 // functions/src/database/listings/relatedAccounts/triggers/onUpdate/index.ts
 
 import * as functions from "firebase-functions";
-import * as admin from "firebase-admin";
+import {admin} from "../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
 import {EventContext} from "firebase-functions";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 import {geocodeAddress} from "../../../../utils/geocoding"; // Import your geocode utility
-
-if (!admin.apps.length) {
-  admin.initializeApp();
-}
 
 const db = admin.firestore();
 

--- a/functions/src/functions/contactform.ts
+++ b/functions/src/functions/contactform.ts
@@ -18,15 +18,11 @@
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
 import * as functions from "firebase-functions";
-import * as admin from "firebase-admin";
+import {admin} from "../utils/firebase";
 import * as nodemailer from "nodemailer";
 import * as cors from "cors";
 
 // Initialize the Firebase admin SDK
-if (!admin.apps.length) {
-  admin.initializeApp();
-}
-
 // Configure CORS middleware
 const corsHandler = cors({origin: true});
 

--- a/functions/src/functions/listings/homepage.ts
+++ b/functions/src/functions/listings/homepage.ts
@@ -20,14 +20,10 @@
 
 /** Firebase Cloud Function for Homepage Listings */
 import * as functions from "firebase-functions";
-import * as admin from "firebase-admin";
+import {admin} from "../../utils/firebase";
 import * as cors from "cors";
 
 // Initialize the Firebase admin SDK
-if (!admin.apps.length) {
-  admin.initializeApp();
-}
-
 const corsHandler = cors({origin: true});
 
 /**

--- a/functions/src/utils/firebase.ts
+++ b/functions/src/utils/firebase.ts
@@ -1,0 +1,7 @@
+import * as admin from "firebase-admin";
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+export {admin};

--- a/functions/test/homepage.spec.ts
+++ b/functions/test/homepage.spec.ts
@@ -3,7 +3,7 @@ import * as sinon from 'sinon';
 const proxyquire = require('proxyquire');
 const adminStub = {firestore: sinon.stub(), apps: [], initializeApp: sinon.stub()};
 const {getHomepageListings} = proxyquire('../src/functions/listings/homepage', {
-  'firebase-admin': adminStub,
+  '../../utils/firebase': {admin: adminStub},
   cors: () => (req: any, res: any, cb: any) => cb(),
 });
 import {Request, Response} from 'express';


### PR DESCRIPTION
## Summary
- centralize Firebase Admin SDK initialization in `functions/src/utils/firebase.ts`
- update all Cloud Functions to import initialized `admin` from the utils module
- adjust tests for new import path

## Testing
- `npm --prefix functions test`

------
https://chatgpt.com/codex/tasks/task_e_6872892904c48326a4475dfb23e0634e