### PR TITLE
Add resume upload field and expand Event model

### DIFF
--- a/shared/models/account.model.ts
+++ b/shared/models/account.model.ts
@@ -99,7 +99,7 @@ export interface ProfessionalInformation {
   skillsAndExpertise?: string[];
   currentJobTitle?: string;
   linkedInProfile?: string;
-  // resumeUpload?: File; // TODO: Add support for resume upload
+  resumeUpload?: File | null;
   educationalBackground?: string;
 }
 
@@ -149,12 +149,14 @@ interface GroupCategory {
 }
 
 interface Event {
-  // TODO: Add support for events
   title: string;
   description?: string;
   startDate: Timestamp;
   endDate: Timestamp;
   location?: string; // Optional, physical location or online link
+  organizerId?: string;
+  attendeeIds?: string[];
+  capacity?: number;
 }
 
 interface User {


### PR DESCRIPTION
## Summary
- support an optional resume upload in `ProfessionalInformation`
- expand the `Event` interface with organizer and attendee data

## Testing
- `npm run test` *(fails: Chrome binary requires snap install)*

------
https://chatgpt.com/codex/tasks/task_e_6873398b630c8326b7c95a5b06ecf07d