### PR TITLE
Fix selectAuthUser for undefined state

### DIFF
--- a/src/app/state/selectors/auth.selectors.ts
+++ b/src/app/state/selectors/auth.selectors.ts
@@ -27,7 +27,8 @@ export const selectAuthState = createFeatureSelector<AuthState>("auth");
 
 export const selectAuthUser = createSelector(
   selectAuthState,
-  (state: AuthState) => state.user,
+  (state: AuthState | undefined): AuthUser | null =>
+    state ? state.user : null,
 );
 
 export const selectIsLoggedIn = createSelector(


### PR DESCRIPTION
## Summary
- handle undefined `auth` state in `selectAuthUser`

## Testing
- `npm run test` *(fails: Chrome browser not found)*

------
https://chatgpt.com/codex/tasks/task_e_68734193a35883269ceb7db111b3ec2d