### PR TITLE
Add test deps install docs

### DIFF
--- a/.github/workflows/ci-pr-deployment.yml
+++ b/.github/workflows/ci-pr-deployment.yml
@@ -78,6 +78,12 @@ jobs:
           npm ci                            # Install root project dependencies
           npm --prefix functions ci         # Install functions dependencies
 
+      - name: Install Angular CLI and Chrome
+        run: |
+          npm install -g @angular/cli
+          sudo apt-get update
+          sudo apt-get install -y chromium-browser
+
       # Step 5: Set environment variables
       - name: Set environment variables
         run: |

--- a/.github/workflows/ci.yml.example
+++ b/.github/workflows/ci.yml.example
@@ -23,6 +23,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Angular CLI and Chrome
+        run: |
+          npm install -g @angular/cli
+          sudo apt-get update
+          sudo apt-get install -y chromium-browser
+
       - name: Build and Test
         run: npm run build && npm run test
         # env:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,17 @@ To execute the unit tests for both the Angular application and Firebase function
 npm run test
 ```
 
-This command will build the project and run all Jasmine and Mocha tests.
+This command will build the project and run all Jasmine and Mocha tests. Ensure
+`@angular/cli` is installed globally and that a headless Chrome binary is
+available so Karma can launch the browser.
+
+Example installation on Ubuntu:
+
+```bash
+npm install -g @angular/cli
+sudo apt-get update
+sudo apt-get install -y chromium-browser
+```
 
 ## Latest Development Environment
 

--- a/functions/README.md
+++ b/functions/README.md
@@ -61,4 +61,12 @@ npm --prefix functions test
 ```
 
 From the repository root you can also run `npm run test` which executes
-Angular and functions tests together.
+Angular and functions tests together. Ensure the global `@angular/cli` package
+and a headless Chrome binary are installed beforehand so Karma can launch the
+browser. On Ubuntu you can install them with:
+
+```bash
+npm install -g @angular/cli
+sudo apt-get update
+sudo apt-get install -y chromium-browser
+```


### PR DESCRIPTION
## Summary
- mention installing `@angular/cli` and headless Chrome before running tests
- install Angular CLI and Chrome in example CI workflow
- install Angular CLI and Chrome in PR deployment workflow

## Testing
- `npm run test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6873417564f08326a3be0f9e1b11b143