### PR TITLE
Add resume upload integration

### DIFF
--- a/shared/models/account.model.ts
+++ b/shared/models/account.model.ts
@@ -99,6 +99,11 @@ export interface ProfessionalInformation {
   skillsAndExpertise?: string[];
   currentJobTitle?: string;
   linkedInProfile?: string;
+  /**
+   * Local resume file selected by the user. This should be uploaded to
+   * Firebase Storage during account creation or updates and replaced
+   * with the resulting download URL.
+   */
   resumeUpload?: File | null;
   educationalBackground?: string;
 }

--- a/shared/models/account.model.ts
+++ b/shared/models/account.model.ts
@@ -100,11 +100,10 @@ export interface ProfessionalInformation {
   currentJobTitle?: string;
   linkedInProfile?: string;
   /**
-   * Local resume file selected by the user. This should be uploaded to
-   * Firebase Storage during account creation or updates and replaced
-   * with the resulting download URL.
+   * Local resume file selected by the user or the resulting download URL
+   * after the file has been uploaded to Firebase Storage.
    */
-  resumeUpload?: File | null;
+  resumeUpload?: File | string | null;
   educationalBackground?: string;
 }
 

--- a/src/app/core/services/storage.service.ts
+++ b/src/app/core/services/storage.service.ts
@@ -32,7 +32,7 @@ export class StorageService {
   async uploadFile(path: string, file: File): Promise<string> {
     const fileRef = this.storage.ref(path);
 
-    await this.storage.upload(path, file);
+    await this.storage.upload(path, file, {contentType: file.type});
     return firstValueFrom(fileRef.getDownloadURL());
   }
 }

--- a/src/app/modules/account/pages/details/components/professional-info/professional-info.component.html
+++ b/src/app/modules/account/pages/details/components/professional-info/professional-info.component.html
@@ -57,6 +57,12 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
               professionalInfo?.linkedInProfile
             }}</a>
           </div>
+          <div class="info-block" *ngIf="professionalInfo?.resumeUpload">
+            <h2>Resume</h2>
+            <ion-button fill="clear" [href]="professionalInfo?.resumeUpload" target="_blank">
+              Download
+            </ion-button>
+          </div>
         </ion-col>
       </ion-row>
     </ion-grid>

--- a/src/app/modules/account/pages/edit/components/professional-info-form/professional-info-form.component.html
+++ b/src/app/modules/account/pages/edit/components/professional-info-form/professional-info-form.component.html
@@ -122,6 +122,26 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
           ></ion-textarea>
         </ion-col>
       </ion-row>
+      <!-- Resume Upload -->
+      <ion-row>
+        <ion-col>
+          <ion-item lines="none">
+            <ion-label>Upload Resume</ion-label>
+            <ion-button fill="outline" (click)="resumeInput.click()">
+              Choose File
+            </ion-button>
+            <input
+              type="file"
+              (change)="onFileSelect($event)"
+              #resumeInput
+              hidden
+            />
+          </ion-item>
+          <ion-text *ngIf="resumeFileName">
+            Selected File: {{ resumeFileName }}
+          </ion-text>
+        </ion-col>
+      </ion-row>
       <!-- Save Button -->
       <ion-row>
         <ion-col>

--- a/src/app/modules/account/pages/edit/components/professional-info-form/professional-info-form.component.html
+++ b/src/app/modules/account/pages/edit/components/professional-info-form/professional-info-form.component.html
@@ -132,6 +132,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
             </ion-button>
             <input
               type="file"
+              accept=".pdf,.doc,.docx"
               (change)="onFileSelect($event)"
               #resumeInput
               hidden

--- a/src/app/modules/account/pages/edit/components/professional-info-form/professional-info-form.component.ts
+++ b/src/app/modules/account/pages/edit/components/professional-info-form/professional-info-form.component.ts
@@ -19,7 +19,7 @@
 ***********************************************************************************************/
 // professional-info.component.ts
 
-import {Component, Input, OnInit} from "@angular/core";
+import {Component, Input, OnInit, ElementRef, ViewChild} from "@angular/core";
 import {Account, ProfessionalInformation} from "@shared/models/account.model";
 import {FormGroup, FormBuilder, Validators} from "@angular/forms";
 import {Store} from "@ngrx/store";
@@ -35,6 +35,9 @@ export class ProfessionalInfoFormComponent implements OnInit {
   @Input() account?: Account;
   professionalInformationForm: FormGroup;
   public skillsOptions: string[] = skillsOptions;
+  resumeFileName = "";
+  resumeFile: File | null = null;
+  @ViewChild("resumeInput") resumeInput!: ElementRef<HTMLInputElement>;
 
   constructor(
     private fb: FormBuilder,
@@ -48,6 +51,7 @@ export class ProfessionalInfoFormComponent implements OnInit {
       currentJobTitle: [""],
       linkedInProfile: [""],
       educationalBackground: [""],
+      resumeUpload: [null],
     });
   }
 
@@ -72,14 +76,32 @@ export class ProfessionalInfoFormComponent implements OnInit {
           this.account.professionalInformation.linkedInProfile || "",
         educationalBackground:
           this.account.professionalInformation.educationalBackground || "",
+        resumeUpload: null,
+      });
+    }
+  }
+
+  onFileSelect(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (input.files && input.files.length > 0) {
+      this.resumeFile = input.files[0];
+      this.resumeFileName = this.resumeFile.name;
+      this.professionalInformationForm.patchValue({
+        resumeUpload: this.resumeFile,
       });
     }
   }
 
   onSubmit() {
     if (this.professionalInformationForm.valid && this.account) {
-      const updatedProfessionalInformation: ProfessionalInformation =
-        this.professionalInformationForm.value;
+      const formValue = this.professionalInformationForm.value;
+      const updatedProfessionalInformation: ProfessionalInformation = {
+        ...formValue,
+        resumeUpload:
+          this.resumeFile ||
+          this.account.professionalInformation?.resumeUpload ||
+          null,
+      };
 
       const updatedAccount: Account = {
         ...this.account,

--- a/src/app/state/effects/account.effects.ts
+++ b/src/app/state/effects/account.effects.ts
@@ -501,10 +501,9 @@ export class AccountEffects {
 
     let resumeUrl: string | null = null;
     if (file instanceof File) {
-      resumeUrl = await this.storageService.uploadFile(
-        `accounts/${accountId}/resume.pdf`,
-        file,
-      );
+      const extension = file.name.split(".").pop()?.toLowerCase() || "pdf";
+      const filePath = `accounts/${accountId}/resume.${extension}`;
+      resumeUrl = await this.storageService.uploadFile(filePath, file);
       await this.firestoreService.updateDocument("accounts", accountId, {
         professionalInformation: {
           ...newAccount.professionalInformation,
@@ -531,10 +530,9 @@ export class AccountEffects {
 
     const file = account.professionalInformation?.resumeUpload;
     if (file instanceof File) {
-      const resumeUrl = await this.storageService.uploadFile(
-        `accounts/${account.id}/resume.pdf`,
-        file,
-      );
+      const extension = file.name.split(".").pop()?.toLowerCase() || "pdf";
+      const filePath = `accounts/${account.id}/resume.${extension}`;
+      const resumeUrl = await this.storageService.uploadFile(filePath, file);
       updatedAccount = {
         ...updatedAccount,
         professionalInformation: {

--- a/storage.rules
+++ b/storage.rules
@@ -7,7 +7,8 @@ service firebase.storage {
       allow write: if 
       	request.auth != null && 
         request.auth.uid == accountId && 
-        request.resource.contentType.matches('image/.*') && 
+        (request.resource.contentType.matches('image/.*') ||
+          request.resource.contentType == 'application/pdf') &&
         request.resource.size < 5 * 1024 * 1024; // 5MB
     }
 

--- a/storage.rules
+++ b/storage.rules
@@ -8,7 +8,9 @@ service firebase.storage {
       	request.auth != null && 
         request.auth.uid == accountId && 
         (request.resource.contentType.matches('image/.*') ||
-          request.resource.contentType == 'application/pdf') &&
+          request.resource.contentType == 'application/pdf' ||
+          request.resource.contentType == 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' ||
+          request.resource.contentType == 'application/msword') &&
         request.resource.size < 5 * 1024 * 1024; // 5MB
     }
 


### PR DESCRIPTION
## Summary
- support storing a resume in `ProfessionalInformation`
- allow resume uploads when editing professional information
- display resume link in profile details
- handle resume files in account creation and update effects

## Testing
- `npm run lint` *(fails: lint errors)*
- `npm test` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_6873419dcaf483269764896fa56e4c1a