### PR TITLE
Update footer links to use routerLink

### DIFF
--- a/src/app/modules/auth/pages/landing/landing.page.html
+++ b/src/app/modules/auth/pages/landing/landing.page.html
@@ -176,18 +176,10 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
             <h3>Quick Links</h3>
             <ul>
               <li>
-                <a
-                  href="https://ascendynamics.org/page/about-us"
-                  target="_blank"
-                  >About Us</a
-                >
+                <a routerLink="/info/about-us">About Us</a>
               </li>
               <li>
-                <a
-                  href="https://ascendynamics.org/page/contact-us"
-                  target="_blank"
-                  >Contact</a
-                >
+                <a routerLink="/info/contact-us">Contact</a>
               </li>
               <li>
                 <a (click)="openLegalModal('privacyPolicy')">Privacy Policy</a>


### PR DESCRIPTION
## Summary
- use internal router links for About Us and Contact links in landing page

## Testing
- `npm test` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_6873e20fb4c88326831f714b0e1ada50