### PR TITLE
Add info pages to menu

### DIFF
--- a/src/app/shared/components/menu/menu.component.html
+++ b/src/app/shared/components/menu/menu.component.html
@@ -85,6 +85,23 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
           </ion-item>
         </ion-menu-toggle>
       </ion-list>
+      <!-- Info Pages Section -->
+      <ion-list>
+        <ion-list-header>
+          <strong>Learn More</strong>
+        </ion-list-header>
+        <ion-menu-toggle auto-hide="false">
+          <ion-item
+            *ngFor="let info of infoPages"
+            [routerLink]="info.url"
+            lines="none"
+            detail="false"
+          >
+            <ion-icon aria-hidden="true" slot="start" [name]="info.icon"></ion-icon>
+            <ion-label>{{ info.title }}</ion-label>
+          </ion-item>
+        </ion-menu-toggle>
+      </ion-list>
       <!-- Project Links Section -->
       <ion-list>
         <ion-list-header>

--- a/src/app/shared/components/menu/menu.component.ts
+++ b/src/app/shared/components/menu/menu.component.ts
@@ -42,6 +42,7 @@ export class MenuComponent implements OnInit, OnDestroy {
   user: AuthUser | null = null;
   menuPages: MenuItem[] = [];
   project: MenuItem[] = [];
+  infoPages: MenuItem[] = [];
 
   constructor(
     private store: Store,
@@ -90,6 +91,18 @@ export class MenuComponent implements OnInit, OnDestroy {
       },
     ];
 
+    // Initialize informational page links
+    this.infoPages = [
+      {title: "About Us", url: "/info/about-us", icon: "information-circle"},
+      {title: "Contact Us", url: "/info/contact-us", icon: "mail"},
+      {title: "Services", url: "/info/services", icon: "construct"},
+      {title: "Startups", url: "/info/startups", icon: "rocket"},
+      {title: "Nonprofits", url: "/info/nonprofits", icon: "heart"},
+      {title: "Event Calendar", url: "/info/event-calendar", icon: "calendar"},
+      {title: "Our Team", url: "/info/team", icon: "people"},
+      {title: "Think Tank", url: "/info/think-tank", icon: "bulb"},
+    ];
+
     // Combine authUser and language change observables
     const authUser$ = this.store.select(selectAuthUser);
     const langChange$ = this.translate.onLangChange;
@@ -130,6 +143,8 @@ export class MenuComponent implements OnInit, OnDestroy {
       //   icon: "business",
       // },
     ];
+
+    this.menuPages = [...this.menuPages, ...this.infoPages];
   }
 
   private setUserMenuItems() {
@@ -173,6 +188,8 @@ export class MenuComponent implements OnInit, OnDestroy {
       //   icon: "newspaper",
       // },
     ];
+
+    this.menuPages = [...this.menuPages, ...this.infoPages];
   }
 
   // Handle button clicks in menu items


### PR DESCRIPTION
## Summary
- add internal info page links in menu component
- display new info page list in menu template

## Testing
- `npm test` *(fails: No Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_6873e21b25908326913560ad13612c8a