### PR TITLE
Fix Firestore trigger imports

### DIFF
--- a/functions/src/database/accounts/relatedAccounts/triggers/onCreate/index.ts
+++ b/functions/src/database/accounts/relatedAccounts/triggers/onCreate/index.ts
@@ -17,10 +17,10 @@
 * You should have received a copy of the GNU Affero General Public License
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
-import * as functions from "firebase-functions";
+import * as functions from "firebase-functions/v1";
 import {admin} from "../../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
-import {EventContext} from "firebase-functions";
+import {EventContext} from "firebase-functions/v1";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 
 // Initialize the Firebase admin SDK

--- a/functions/src/database/accounts/relatedAccounts/triggers/onDelete/index.ts
+++ b/functions/src/database/accounts/relatedAccounts/triggers/onDelete/index.ts
@@ -17,10 +17,10 @@
 * You should have received a copy of the GNU Affero General Public License
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
-import * as functions from "firebase-functions";
+import * as functions from "firebase-functions/v1";
 import {admin} from "../../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
-import {EventContext} from "firebase-functions";
+import {EventContext} from "firebase-functions/v1";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 
 // Initialize the Firebase admin SDK

--- a/functions/src/database/accounts/relatedAccounts/triggers/onUpdate/index.ts
+++ b/functions/src/database/accounts/relatedAccounts/triggers/onUpdate/index.ts
@@ -17,10 +17,10 @@
 * You should have received a copy of the GNU Affero General Public License
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
-import * as functions from "firebase-functions";
+import * as functions from "firebase-functions/v1";
 import {admin} from "../../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
-import {Change, EventContext} from "firebase-functions";
+import {Change, EventContext} from "firebase-functions/v1";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 
 // Initialize the Firebase admin SDK

--- a/functions/src/database/accounts/relatedListings/triggers/onDelete/index.ts
+++ b/functions/src/database/accounts/relatedListings/triggers/onDelete/index.ts
@@ -19,10 +19,10 @@
 ***********************************************************************************************/
 // functions/src/database/accounts/relatedListings/triggers/onDelete/index.ts
 
-import * as functions from "firebase-functions";
+import * as functions from "firebase-functions/v1";
 import {admin} from "../../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
-import {EventContext} from "firebase-functions";
+import {EventContext} from "firebase-functions/v1";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 
 const db = admin.firestore();

--- a/functions/src/database/accounts/triggers/onUpdate/index.ts
+++ b/functions/src/database/accounts/triggers/onUpdate/index.ts
@@ -18,7 +18,7 @@
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
 
-import * as functions from "firebase-functions";
+import * as functions from "firebase-functions/v1";
 import {admin} from "../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";

--- a/functions/src/database/listings/relatedAccounts/triggers/onCreate/index.ts
+++ b/functions/src/database/listings/relatedAccounts/triggers/onCreate/index.ts
@@ -19,10 +19,10 @@
 ***********************************************************************************************/
 // functions/src/database/listings/relatedAccounts/triggers/onCreate/index.ts
 
-import * as functions from "firebase-functions";
+import * as functions from "firebase-functions/v1";
 import {admin} from "../../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
-import {EventContext} from "firebase-functions";
+import {EventContext} from "firebase-functions/v1";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 
 const db = admin.firestore();

--- a/functions/src/database/listings/relatedAccounts/triggers/onUpdate/index.ts
+++ b/functions/src/database/listings/relatedAccounts/triggers/onUpdate/index.ts
@@ -19,10 +19,10 @@
 ***********************************************************************************************/
 // functions/src/database/listings/relatedAccounts/triggers/onCreate/index.ts
 
-import * as functions from "firebase-functions";
+import * as functions from "firebase-functions/v1";
 import {admin} from "../../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
-import {EventContext} from "firebase-functions";
+import {EventContext} from "firebase-functions/v1";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 
 const db = admin.firestore();

--- a/functions/src/database/listings/triggers/onCreate/index.ts
+++ b/functions/src/database/listings/triggers/onCreate/index.ts
@@ -18,10 +18,10 @@
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
 
-import * as functions from "firebase-functions";
+import * as functions from "firebase-functions/v1";
 import {admin} from "../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
-import {EventContext} from "firebase-functions";
+import {EventContext} from "firebase-functions/v1";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 import {geocodeAddress} from "../../../../utils/geocoding"; // <-- using the same utility
 

--- a/functions/src/database/listings/triggers/onDelete/index.ts
+++ b/functions/src/database/listings/triggers/onDelete/index.ts
@@ -19,10 +19,10 @@
 ***********************************************************************************************/
 // functions/src/database/listings/triggers/onDelete/index.ts
 
-import * as functions from "firebase-functions";
+import * as functions from "firebase-functions/v1";
 import {admin} from "../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
-import {EventContext} from "firebase-functions";
+import {EventContext} from "firebase-functions/v1";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 
 const db = admin.firestore();

--- a/functions/src/database/listings/triggers/onUpdate/index.ts
+++ b/functions/src/database/listings/triggers/onUpdate/index.ts
@@ -19,10 +19,10 @@
 ***********************************************************************************************/
 // functions/src/database/listings/relatedAccounts/triggers/onUpdate/index.ts
 
-import * as functions from "firebase-functions";
+import * as functions from "firebase-functions/v1";
 import {admin} from "../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
-import {EventContext} from "firebase-functions";
+import {EventContext} from "firebase-functions/v1";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 import {geocodeAddress} from "../../../../utils/geocoding"; // Import your geocode utility
 


### PR DESCRIPTION
## Summary
- fix Firestore trigger imports to use `firebase-functions/v1`

## Testing
- `npm test` *(fails: No binary for Chrome)*
- `npm run build --prefix functions`


------
https://chatgpt.com/codex/tasks/task_e_6875b8cf0a30832697f6e85ea58af2c1