### PR TITLE
Fix Cloud Functions runtime

### DIFF
--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -34,7 +34,7 @@
         "typescript": "~5.4.0"
       },
       "engines": {
-        "node": "20"
+        "node": "18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -12,7 +12,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "20"
+    "node": "18"
   },
   "main": "lib/functions/src/index.js",
   "dependencies": {


### PR DESCRIPTION
## Summary
- set Node runtime to 18 so Firebase uses 1st gen runtime

## Testing
- `npm run test` *(fails: cannot start Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_6875ca273ef88326b492fd45bb3ac2ff