### PR TITLE
Fix Cloud Functions runtime

### DIFF
--- a/.github/workflows/ci-pr-deployment.yml
+++ b/.github/workflows/ci-pr-deployment.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: '18'
 
       # Step 3: Install dependencies
       - name: Install dependencies
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: '18'
 
       # Step 3: Cache node modules
       - name: Cache node modules
@@ -68,9 +68,9 @@ jobs:
             ~/.npm                    # NPM cache directory
             node_modules              # Root node_modules
             functions/node_modules    # Functions node_modules
-          key: ${{ runner.os }}-node-20-${{ hashFiles('package-lock.json', 'functions/package-lock.json') }}
+          key: ${{ runner.os }}-node-18-${{ hashFiles('package-lock.json', 'functions/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-20-
+            ${{ runner.os }}-node-18-
 
       # Step 4: Install dependencies
       - name: Install dependencies
@@ -140,7 +140,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: '18'
 
       # Install dependencies
       - name: Install dependencies

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: '18'
 
       # Install dependencies
       - name: Install Dependencies

--- a/.github/workflows/pr-domain-cleanup.yml
+++ b/.github/workflows/pr-domain-cleanup.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: '18'
       - name: Install dependencies
         run: npm ci
       - name: Remove authorized preview domain

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '20'
+          node-version: '18'
 
       # 3. Install Dependencies
       - name: Install Dependencies

--- a/firebase.json
+++ b/firebase.json
@@ -12,7 +12,8 @@
       "predeploy": [
         "npm --prefix \"$RESOURCE_DIR\" run lint",
         "npm --prefix \"$RESOURCE_DIR\" run build"
-      ]
+      ],
+      "runtime": "nodejs18"
     }
   ],
   "database": {

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -34,7 +34,7 @@
         "typescript": "~5.4.0"
       },
       "engines": {
-        "node": "20"
+        "node": "18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -12,7 +12,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "20"
+    "node": "18"
   },
   "main": "lib/functions/src/index.js",
   "dependencies": {


### PR DESCRIPTION
## Summary
- set Node runtime to 18 so Firebase uses 1st gen runtime
- specify the runtime explicitly in `firebase.json`
- use Node 18 in all GitHub workflows

## Testing
- `npm run test` *(fails: Chrome not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875ca273ef88326b492fd45bb3ac2ff