### PR TITLE
Migrate Firebase functions to gen2

### DIFF
--- a/functions/src/database/accounts/relatedAccounts/triggers/onCreate/index.ts
+++ b/functions/src/database/accounts/relatedAccounts/triggers/onCreate/index.ts
@@ -17,10 +17,9 @@
 * You should have received a copy of the GNU Affero General Public License
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
-import * as functions from "firebase-functions/v1";
+import {onDocumentCreated, FirestoreEvent} from "firebase-functions/v2/firestore";
 import {admin} from "../../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
-import {EventContext} from "firebase-functions/v1";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 
 // Initialize the Firebase admin SDK
@@ -30,12 +29,15 @@ const db = admin.firestore();
 /**
  * Cloud Function triggered when a new document is created in the `relatedAccounts` sub-collection of an `accounts` document.
  */
-export const onCreateRelatedAccount = functions.firestore
-  .document("accounts/{accountId}/relatedAccounts/{relatedAccountId}")
-  .onCreate(async (_snapshot: QueryDocumentSnapshot, context: EventContext) => {
-    const accountId = context.params.accountId;
-    const relatedAccountId = context.params.relatedAccountId;
-
+export const onCreateRelatedAccount = onDocumentCreated(
+  {
+    document: "accounts/{accountId}/relatedAccounts/{relatedAccountId}",
+    region: "us-central1",
+  },
+  async (event: FirestoreEvent<QueryDocumentSnapshot>) => {
+    const accountId = event.params.accountId;
+    const relatedAccountId = event.params.relatedAccountId;
+    
     // Early exit if IDs match to prevent self-referential relationships
     if (accountId === relatedAccountId) {
       logger.error(

--- a/functions/src/database/accounts/relatedAccounts/triggers/onDelete/index.ts
+++ b/functions/src/database/accounts/relatedAccounts/triggers/onDelete/index.ts
@@ -17,10 +17,9 @@
 * You should have received a copy of the GNU Affero General Public License
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
-import * as functions from "firebase-functions/v1";
+import {onDocumentDeleted, FirestoreEvent} from "firebase-functions/v2/firestore";
 import {admin} from "../../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
-import {EventContext} from "firebase-functions/v1";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 
 // Initialize the Firebase admin SDK
@@ -30,22 +29,24 @@ const db = admin.firestore();
 /**
  * Cloud Function triggered when a document in the `relatedAccounts` sub-collection of an `accounts` document is deleted.
  */
-export const onDeleteRelatedAccount = functions.firestore
-  .document("accounts/{accountId}/relatedAccounts/{relatedAccountId}")
-  .onDelete(handleRelatedAccountDelete);
+export const onDeleteRelatedAccount = onDocumentDeleted(
+  {
+    document: "accounts/{accountId}/relatedAccounts/{relatedAccountId}",
+    region: "us-central1",
+  },
+  handleRelatedAccountDelete,
+);
 
 /**
  * Handles the deletion of a related account document, ensuring the corresponding reciprocal document in the target account is also deleted.
  *
- * @param {QueryDocumentSnapshot} _snapshot - The snapshot of the document being deleted.
- * @param {EventContext} context - The context of the event, providing parameters and identifiers.
- */
+ * @param {FirestoreEvent<QueryDocumentSnapshot>} event - The event for the deleted document.
+*/
 async function handleRelatedAccountDelete(
-  _snapshot: QueryDocumentSnapshot,
-  context: EventContext,
+  event: FirestoreEvent<QueryDocumentSnapshot>,
 ) {
-  const accountId = context.params.accountId;
-  const relatedAccountId = context.params.relatedAccountId;
+  const accountId = event.params.accountId;
+  const relatedAccountId = event.params.relatedAccountId;
   try {
     const reciprocalRelatedAccountRef = db
       .collection("accounts")

--- a/functions/src/database/accounts/relatedListings/triggers/onDelete/index.ts
+++ b/functions/src/database/accounts/relatedListings/triggers/onDelete/index.ts
@@ -19,18 +19,21 @@
 ***********************************************************************************************/
 // functions/src/database/accounts/relatedListings/triggers/onDelete/index.ts
 
-import * as functions from "firebase-functions/v1";
+import {onDocumentDeleted, FirestoreEvent} from "firebase-functions/v2/firestore";
 import {admin} from "../../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
-import {EventContext} from "firebase-functions/v1";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 
 const db = admin.firestore();
 
 // New trigger for relatedListings onDelete
-export const onDeleteAccountsRelatedListing = functions.firestore
-  .document("accounts/{accountId}/relatedListings/{listingId}")
-  .onDelete(handleAccountsRelatedListingDelete);
+export const onDeleteAccountsRelatedListing = onDocumentDeleted(
+  {
+    document: "accounts/{accountId}/relatedListings/{listingId}",
+    region: "us-central1",
+  },
+  handleAccountsRelatedListingDelete,
+);
 
 /**
  * Handles the deletion of a relatedListing document in Firestore.
@@ -38,15 +41,13 @@ export const onDeleteAccountsRelatedListing = functions.firestore
  * this function deletes the corresponding relatedAccount document
  * under the listing, unlinking the account from the listing.
  *
- * @param {QueryDocumentSnapshot} snapshot - The snapshot of the deleted relatedListing document.
- * @param {EventContext} context - The context object containing metadata about the event, including accountId and listingId.
+ * @param {FirestoreEvent<QueryDocumentSnapshot>} event - The event for the deleted document.
  * @return {Promise<void>} A promise that resolves when the relatedAccount document is deleted, or logs an error if it fails.
- */
+*/
 async function handleAccountsRelatedListingDelete(
-  snapshot: QueryDocumentSnapshot,
-  context: EventContext,
+  event: FirestoreEvent<QueryDocumentSnapshot>,
 ) {
-  const {accountId, listingId} = context.params;
+  const {accountId, listingId} = event.params;
 
   try {
     const relatedAccountRef = db

--- a/functions/src/database/listings/relatedAccounts/triggers/onCreate/index.ts
+++ b/functions/src/database/listings/relatedAccounts/triggers/onCreate/index.ts
@@ -19,34 +19,33 @@
 ***********************************************************************************************/
 // functions/src/database/listings/relatedAccounts/triggers/onCreate/index.ts
 
-import * as functions from "firebase-functions/v1";
+import {onDocumentCreated, FirestoreEvent} from "firebase-functions/v2/firestore";
 import {admin} from "../../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
-import {EventContext} from "firebase-functions/v1";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 
 const db = admin.firestore();
 
 // New trigger for relatedAccounts onCreate
-export const onCreateListingsRelatedAccount = functions.firestore
-  .document("listings/{listingId}/relatedAccounts/{accountId}")
-  .onCreate(handleListingsRelatedAccountCreate);
+export const onCreateListingsRelatedAccount = onDocumentCreated(
+  {document: "listings/{listingId}/relatedAccounts/{accountId}", region: "us-central1"},
+  handleListingsRelatedAccountCreate,
+);
 
 /**
  * Handles the creation of a new relatedAccount document in Firestore.
  * When a user applies to a listing, this function creates a relatedListing
  * document under the applicant's account, linking the account to the listing.
  *
- * @param {QueryDocumentSnapshot} snapshot - The snapshot of the newly created relatedAccount document.
- * @param {EventContext} context - The context object containing metadata about the event, including listingId and accountId.
+ * @param {FirestoreEvent<QueryDocumentSnapshot>} event - The event for the newly created relatedAccount document.
  * @return {Promise<void>} A promise that resolves when the relatedListing document is created, or logs an error if it fails.
- */
+*/
 async function handleListingsRelatedAccountCreate(
-  snapshot: QueryDocumentSnapshot,
-  context: EventContext,
+  event: FirestoreEvent<QueryDocumentSnapshot>,
 ) {
-  const {listingId, accountId} = context.params;
-  const relatedAccount = snapshot.data();
+  const {listingId, accountId} = event.params;
+  const snapshot = event.data;
+  const relatedAccount = snapshot?.data();
 
   try {
     const relatedListingDoc = await db

--- a/functions/src/database/listings/triggers/onCreate/index.ts
+++ b/functions/src/database/listings/triggers/onCreate/index.ts
@@ -18,10 +18,9 @@
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
 
-import * as functions from "firebase-functions/v1";
+import {onDocumentCreated, FirestoreEvent} from "firebase-functions/v2/firestore";
 import {admin} from "../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
-import {EventContext} from "firebase-functions/v1";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 import {geocodeAddress} from "../../../../utils/geocoding"; // <-- using the same utility
 
@@ -29,9 +28,10 @@ import {geocodeAddress} from "../../../../utils/geocoding"; // <-- using the sam
 // Reference to the Firestore database
 const db = admin.firestore();
 
-export const onCreateListing = functions.firestore
-  .document("listings/{listingId}")
-  .onCreate(handleListingCreate);
+export const onCreateListing = onDocumentCreated(
+  {document: "listings/{listingId}", region: "us-central1"},
+  handleListingCreate,
+);
 
 /**
  * Handles the creation of a new listing document in Firestore.
@@ -40,16 +40,15 @@ export const onCreateListing = functions.firestore
  * - Creates a relatedListing document in `accounts/{accountId}/relatedListings`
  * Both documents are linked to the listing creator with "owner" relationship status.
  *
- * @param {QueryDocumentSnapshot} snapshot - The snapshot of the newly created listing document.
- * @param {EventContext} context - The context object containing metadata about the event, including the listing ID.
+ * @param {FirestoreEvent<QueryDocumentSnapshot>} event - The event for the newly created listing document.
  * @return {Promise<void>} A promise that resolves when both relationship documents are created, or logs an error if it fails.
- */
+*/
 async function handleListingCreate(
-  snapshot: QueryDocumentSnapshot,
-  context: EventContext,
+  event: FirestoreEvent<QueryDocumentSnapshot>,
 ) {
-  const listingId = context.params.listingId;
-  const listing = snapshot.data();
+  const listingId = event.params.listingId;
+  const snapshot = event.data;
+  const listing = snapshot?.data();
   const accountId = listing.createdBy;
 
   if (!accountId) {
@@ -97,7 +96,7 @@ async function handleListingCreate(
       );
 
       // 2) Update the listing doc with geocoded addresses
-      await snapshot.ref.update({
+      await snapshot?.ref.update({
         contactInformation: {addresses: geocodedAddresses},
       });
       logger.info(`Successfully geocoded addresses for listing ${listingId}`);

--- a/functions/src/database/listings/triggers/onDelete/index.ts
+++ b/functions/src/database/listings/triggers/onDelete/index.ts
@@ -19,33 +19,31 @@
 ***********************************************************************************************/
 // functions/src/database/listings/triggers/onDelete/index.ts
 
-import * as functions from "firebase-functions/v1";
+import {onDocumentDeleted, FirestoreEvent} from "firebase-functions/v2/firestore";
 import {admin} from "../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
-import {EventContext} from "firebase-functions/v1";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 
 const db = admin.firestore();
 
 // Trigger for listings onDelete
-export const onDeleteListing = functions.firestore
-  .document("listings/{listingId}")
-  .onDelete(handleListingDelete);
+export const onDeleteListing = onDocumentDeleted(
+  {document: "listings/{listingId}", region: "us-central1"},
+  handleListingDelete,
+);
 
 /**
  * Handles the deletion of a listing document in Firestore.
  * When a listing is deleted, this function deletes all relatedListing
  * documents under all accounts that are linked to this listing.
  *
- * @param {QueryDocumentSnapshot} snapshot - The snapshot of the deleted listing document.
- * @param {EventContext} context - The context object containing metadata about the event, including listingId.
+ * @param {FirestoreEvent<QueryDocumentSnapshot>} event - The event for the deleted listing document.
  * @return {Promise<void>} A promise that resolves when all relatedListings are deleted, or logs an error if it fails.
- */
+*/
 async function handleListingDelete(
-  snapshot: QueryDocumentSnapshot,
-  context: EventContext,
+  event: FirestoreEvent<QueryDocumentSnapshot>,
 ) {
-  const {listingId} = context.params;
+  const {listingId} = event.params;
 
   try {
     // Get all related accounts for this listing

--- a/functions/src/database/listings/triggers/onUpdate/index.ts
+++ b/functions/src/database/listings/triggers/onUpdate/index.ts
@@ -19,10 +19,13 @@
 ***********************************************************************************************/
 // functions/src/database/listings/relatedAccounts/triggers/onUpdate/index.ts
 
-import * as functions from "firebase-functions/v1";
+import {
+  onDocumentUpdated,
+  FirestoreEvent,
+  Change,
+} from "firebase-functions/v2/firestore";
 import {admin} from "../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
-import {EventContext} from "firebase-functions/v1";
 import {QueryDocumentSnapshot} from "firebase-admin/firestore";
 import {geocodeAddress} from "../../../../utils/geocoding"; // Import your geocode utility
 
@@ -32,9 +35,10 @@ const db = admin.firestore();
  * Firebase Cloud Function trigger that handles updates to listing documents.
  * Updates all related documents when a listing is modified and geocodes addresses if they've changed.
  */
-export const onUpdateListing = functions.firestore
-  .document("listings/{listingId}")
-  .onUpdate(handleListingUpdate);
+export const onUpdateListing = onDocumentUpdated(
+  {document: "listings/{listingId}", region: "us-central1"},
+  handleListingUpdate,
+);
 
 /**
  * Handles updates to a listing document in Firestore.
@@ -43,17 +47,15 @@ export const onUpdateListing = functions.firestore
  * 3. Update all relatedListing docs in `accounts/{accountId}/relatedListings`
  * Fresh account data is fetched to ensure accuracy of the updates.
  *
- * @param {functions.Change<QueryDocumentSnapshot>} change - Contains both the previous and current versions of the document
- * @param {EventContext} context - The context object containing metadata about the event
+ * @param {FirestoreEvent<Change<QueryDocumentSnapshot>>} event - Contains the before and after versions of the document
  * @return {Promise<void>} A promise that resolves when all relationship documents are updated
- */
+*/
 async function handleListingUpdate(
-  change: functions.Change<QueryDocumentSnapshot>,
-  context: EventContext,
+  event: FirestoreEvent<Change<QueryDocumentSnapshot>>,
 ) {
-  const listingId = context.params.listingId;
-  const updatedListing = change.after.data();
-  const previousListing = change.before.data();
+  const listingId = event.params.listingId;
+  const updatedListing = event.data?.after.data();
+  const previousListing = event.data?.before.data();
 
   // -----------------------
   // 1) Address change logic
@@ -111,7 +113,7 @@ async function handleListingUpdate(
     );
 
     // Update the listing doc with newly geocoded addresses
-    await change.after.ref.update({
+    await event.data?.after.ref.update({
       contactInformation: {addresses: newAddresses},
     });
     logger.info(`Geocoded addresses for listing ${listingId}`);

--- a/functions/src/functions/contactform.ts
+++ b/functions/src/functions/contactform.ts
@@ -17,7 +17,8 @@
 * You should have received a copy of the GNU Affero General Public License
 * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
 ***********************************************************************************************/
-import * as functions from "firebase-functions";
+import {onRequest} from "firebase-functions/v2/https";
+import {config} from "firebase-functions";
 import {admin} from "../utils/firebase";
 import * as nodemailer from "nodemailer";
 import cors from "cors";
@@ -27,8 +28,8 @@ import cors from "cors";
 const corsHandler = cors({origin: true});
 
 // Retrieve Gmail credentials from Firebase config
-const gmailEmail = functions.config().gmail.email;
-const gmailPassword = functions.config().gmail.password;
+const gmailEmail = config().gmail.email;
+const gmailPassword = config().gmail.password;
 
 const transporter = nodemailer.createTransport({
   service: "gmail",
@@ -38,7 +39,7 @@ const transporter = nodemailer.createTransport({
   },
 });
 
-export const submitLead = functions.https.onRequest((req, res) => {
+export const submitLead = onRequest({cors: false}, (req, res) => {
   // Use CORS middleware to allow cross-origin requests
   corsHandler(req, res, async () => {
     if (req.method === "OPTIONS") {

--- a/functions/src/utils/geocoding.ts
+++ b/functions/src/utils/geocoding.ts
@@ -1,7 +1,7 @@
 // utils/geocoding.ts
 import fetch from "node-fetch";
 import * as logger from "firebase-functions/logger";
-import * as functions from "firebase-functions";
+import {config} from "firebase-functions";
 
 /**
  * Represents a geocoding result from Google’s Geocoding API
@@ -13,7 +13,7 @@ export interface GeocodeResult {
 }
 
 // Centralize the API Key (from config or environment)
-const apiKey = functions.config().google?.apikey || process.env.GOOGLE_API_KEY;
+const apiKey = config().google?.apikey || process.env.GOOGLE_API_KEY;
 
 if (!apiKey) {
   logger.error("Google API key is missing. Please set it in Firebase config.");

--- a/functions/test/contactform.spec.ts
+++ b/functions/test/contactform.spec.ts
@@ -17,6 +17,7 @@ describe("submitLead", () => {
     res.setHeader = sinon.stub();
     res.getHeader = sinon.stub();
     res.end = sinon.stub();
+    res.on = sinon.stub();
     return res as Response;
   }
 


### PR DESCRIPTION
## Summary
- migrate most server code to Cloud Functions v2
- adapt geocoding util to new config import
- update HTTP contact form function to `onRequest`
- adjust tests for v2 response API

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68785d0bc29c8326a0595cd64cef2038