### PR TITLE
Add listing detail loading spinner

### DIFF
--- a/src/app/modules/listing/pages/listing-detail/listing-detail.page.html
+++ b/src/app/modules/listing/pages/listing-detail/listing-detail.page.html
@@ -22,6 +22,9 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
 </ion-header>
 
 <ion-content>
+  <ng-container *ngIf="loading$ | async">
+    <ion-spinner name="crescent"></ion-spinner>
+  </ng-container>
   <ng-container *ngIf="listing$ | async as listing">
     <app-hero
       [listing]="listing"

--- a/src/app/modules/listing/pages/listing-detail/listing-detail.page.spec.ts
+++ b/src/app/modules/listing/pages/listing-detail/listing-detail.page.spec.ts
@@ -38,13 +38,17 @@ import {Listing} from "@shared/models/listing.model";
 import * as ListingsActions from "../../../../state/actions/listings.actions";
 import {Timestamp} from "firebase/firestore";
 import {TimestampPipe} from "../../../../shared/pipes/timestamp.pipe";
-import {selectListingById} from "../../../../state/selectors/listings.selectors";
+import {
+  selectListingById,
+  selectLoading,
+} from "../../../../state/selectors/listings.selectors";
 import {selectAuthUser} from "../../../../state/selectors/auth.selectors";
 import {AppState} from "../../../../state/app.state";
 import {AuthUser} from "@shared/models/auth-user.model";
 import {Store} from "@ngrx/store";
 import {Location} from "@angular/common";
 import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
+import {By} from "@angular/platform-browser";
 
 describe("ListingDetailPage", () => {
   let component: ListingDetailPage;
@@ -177,6 +181,7 @@ describe("ListingDetailPage", () => {
     // Override selectors
     store.overrideSelector(selectListingById("123"), mockListing);
     store.overrideSelector(selectAuthUser, mockAuthUser);
+    store.overrideSelector(selectLoading, false);
 
     fixture.detectChanges();
   });
@@ -191,6 +196,15 @@ describe("ListingDetailPage", () => {
     expect(store.dispatch).toHaveBeenCalledWith(
       ListingsActions.loadListingById({id: "123"}),
     );
+  });
+
+  it("should display loading spinner when loading is true", () => {
+    store.overrideSelector(selectLoading, true);
+    store.refreshState();
+    fixture.detectChanges();
+
+    const spinner = fixture.debugElement.query(By.css("ion-spinner"));
+    expect(spinner).toBeTruthy();
   });
 
   // it("should display listing details", (done) => {

--- a/src/app/modules/listing/pages/listing-detail/listing-detail.page.ts
+++ b/src/app/modules/listing/pages/listing-detail/listing-detail.page.ts
@@ -28,7 +28,10 @@ import {Listing} from "@shared/models/listing.model";
 import * as ListingsActions from "../../../../state/actions/listings.actions";
 import {selectAuthUser} from "../../../../state/selectors/auth.selectors";
 import {AppState} from "../../../../state/app.state";
-import {selectListingById} from "../../../../state/selectors/listings.selectors";
+import {
+  selectListingById,
+  selectLoading,
+} from "../../../../state/selectors/listings.selectors";
 import {MetaService} from "../../../../core/services/meta.service";
 
 @Component({
@@ -40,6 +43,7 @@ export class ListingDetailPage implements OnInit {
   private subscription: Subscription | null = null;
   listing$: Observable<Listing | undefined>;
   isOwner$: Observable<boolean>;
+  loading$: Observable<boolean>;
   private listingId: string;
 
   constructor(
@@ -49,6 +53,7 @@ export class ListingDetailPage implements OnInit {
   ) {
     this.listingId = this.route.snapshot.paramMap.get("id") || "";
     this.listing$ = this.store.select(selectListingById(this.listingId));
+    this.loading$ = this.store.select(selectLoading);
 
     // Determine if current user is the listing creator
     this.isOwner$ = combineLatest([


### PR DESCRIPTION
## Summary
- inject listing `loading` selector in listing-detail page
- expose `loading$` observable
- show an `ion-spinner` when the page is loading
- test the loading spinner behavior

## Testing
- `npm test` *(fails: Chrome not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bbcb768108326a32eb194a5f9c11b