### PR TITLE
Add error messages to listing form

### DIFF
--- a/src/app/modules/listing/components/listing-form/listing-form.component.html
+++ b/src/app/modules/listing/components/listing-form/listing-form.component.html
@@ -567,6 +567,19 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                     fill="outline"
                     placeholder="Enter email"
                   ></ion-input>
+                  <ion-note
+                    color="danger"
+                    *ngIf="
+                      email.get('email')?.invalid && email.get('email')?.touched
+                    "
+                  >
+                    <span *ngIf="email.get('email')?.errors?.['required']"
+                      >Email is required.</span
+                    >
+                    <span *ngIf="email.get('email')?.errors?.['email']"
+                      >Enter a valid email.</span
+                    >
+                  </ion-note>
                 </ion-col>
                 <ion-col size="2">
                   <ion-button
@@ -613,59 +626,92 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
               </ion-row>
               <ion-row>
                 <ion-col>
-                  <ion-input
-                    label="Street Address"
-                    label-placement="floating"
-                    fill="outline"
-                    formControlName="street"
-                    type="text"
-                    placeholder="Enter street address"
-                  ></ion-input>
-                </ion-col>
-              </ion-row>
+                <ion-input
+                  label="Street Address"
+                  label-placement="floating"
+                  fill="outline"
+                  formControlName="street"
+                  type="text"
+                  placeholder="Enter street address"
+                ></ion-input>
+                <ion-note
+                  color="danger"
+                  *ngIf="
+                    address.get('street')?.invalid &&
+                    address.get('street')?.touched
+                  "
+                >
+                  Street is required.
+                </ion-note>
+              </ion-col>
+            </ion-row>
               <ion-row>
                 <ion-col size="6">
-                  <ion-input
-                    label="City"
-                    label-placement="floating"
-                    fill="outline"
-                    formControlName="city"
-                    type="text"
-                    placeholder="Enter city"
-                  ></ion-input>
-                </ion-col>
-                <ion-col size="6">
-                  <ion-input
-                    label="State"
-                    label-placement="floating"
-                    fill="outline"
-                    formControlName="state"
-                    type="text"
-                    placeholder="Enter state"
-                  ></ion-input>
-                </ion-col>
-              </ion-row>
+                <ion-input
+                  label="City"
+                  label-placement="floating"
+                  fill="outline"
+                  formControlName="city"
+                  type="text"
+                  placeholder="Enter city"
+                ></ion-input>
+                <ion-note
+                  color="danger"
+                  *ngIf="address.get('city')?.invalid && address.get('city')?.touched"
+                >
+                  City is required.
+                </ion-note>
+              </ion-col>
+              <ion-col size="6">
+                <ion-input
+                  label="State"
+                  label-placement="floating"
+                  fill="outline"
+                  formControlName="state"
+                  type="text"
+                  placeholder="Enter state"
+                ></ion-input>
+                <ion-note
+                  color="danger"
+                  *ngIf="address.get('state')?.invalid && address.get('state')?.touched"
+                >
+                  State is required.
+                </ion-note>
+              </ion-col>
+            </ion-row>
               <ion-row>
                 <ion-col size="6">
-                  <ion-input
-                    label="Country"
-                    label-placement="floating"
-                    fill="outline"
-                    formControlName="country"
-                    type="text"
-                    placeholder="Enter country"
-                  ></ion-input>
-                </ion-col>
-                <ion-col size="6">
-                  <ion-input
-                    label="Postal Code"
-                    label-placement="floating"
-                    fill="outline"
-                    formControlName="zipcode"
-                    type="text"
-                    placeholder="Enter postal code"
-                  ></ion-input>
-                </ion-col>
+                <ion-input
+                  label="Country"
+                  label-placement="floating"
+                  fill="outline"
+                  formControlName="country"
+                  type="text"
+                  placeholder="Enter country"
+                ></ion-input>
+                <ion-note
+                  color="danger"
+                  *ngIf="address.get('country')?.invalid && address.get('country')?.touched"
+                >
+                  Country is required.
+                </ion-note>
+              </ion-col>
+              <ion-col size="6">
+                <ion-input
+                  label="Postal Code"
+                  label-placement="floating"
+                  fill="outline"
+                  formControlName="zipcode"
+                  type="text"
+                  placeholder="Enter postal code"
+                ></ion-input>
+                <ion-note
+                  color="danger"
+                  *ngIf="address.get('zipcode')?.invalid && address.get('zipcode')?.touched"
+                >
+                  Postal code is required and must be valid.
+                </ion-note>
+              </ion-col>
               </ion-row>
               <ion-row>
                 <ion-col>
@@ -730,17 +776,23 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                   ></ion-input>
                 </ion-col>
                 <ion-col size="6">
-                  <ion-input
-                    label="Number"
-                    label-placement="floating"
-                    fill="outline"
-                    formControlName="number"
-                    type="tel"
-                    placeholder="Enter phone number"
-                  ></ion-input>
-                </ion-col>
-                <ion-col size="2">
-                  <ion-button
+                <ion-input
+                  label="Number"
+                  label-placement="floating"
+                  fill="outline"
+                  formControlName="number"
+                  type="tel"
+                  placeholder="Enter phone number"
+                ></ion-input>
+                <ion-note
+                  color="danger"
+                  *ngIf="phone.get('number')?.invalid && phone.get('number')?.touched"
+                >
+                  Phone number is required.
+                </ion-note>
+              </ion-col>
+              <ion-col size="2">
+                <ion-button
                     fill="clear"
                     (click)="
                       removeArrayItem('contactInformation.phoneNumbers', i)

--- a/src/app/modules/listing/components/listing-form/listing-form.component.spec.ts
+++ b/src/app/modules/listing/components/listing-form/listing-form.component.spec.ts
@@ -21,6 +21,7 @@ import {ComponentFixture, TestBed} from "@angular/core/testing";
 import {ListingFormComponent} from "./listing-form.component";
 import {IonicModule} from "@ionic/angular";
 import {ReactiveFormsModule, FormBuilder} from "@angular/forms";
+import {By} from "@angular/platform-browser";
 import {Store} from "@ngrx/store";
 import {MockStore, provideMockStore} from "@ngrx/store/testing";
 import {Timestamp} from "firebase/firestore";
@@ -181,5 +182,56 @@ describe("ListingFormComponent", () => {
 
     component.removeArrayItem("contactInformation.emails", 0);
     expect(component.getFormArray("contactInformation.emails").length).toBe(0);
+  });
+
+  it("should display title validation message when invalid", () => {
+    const titleControl = component.listingForm.get("title");
+    titleControl?.setValue("");
+    titleControl?.markAsTouched();
+    fixture.detectChanges();
+    const notes = fixture.debugElement.queryAll(By.css("ion-note"));
+    const hasError = notes.some((n) =>
+      n.nativeElement.textContent.includes("Title is required."),
+    );
+    expect(hasError).toBeTrue();
+  });
+
+  it("should display description validation message when invalid", () => {
+    const descControl = component.listingForm.get("description");
+    descControl?.setValue("");
+    descControl?.markAsTouched();
+    fixture.detectChanges();
+    const notes = fixture.debugElement.queryAll(By.css("ion-note"));
+    const hasError = notes.some((n) =>
+      n.nativeElement.textContent.includes("Description is required."),
+    );
+    expect(hasError).toBeTrue();
+  });
+
+  it("should display organization validation message when invalid", () => {
+    const orgControl = component.listingForm.get("organization");
+    orgControl?.setValue("");
+    orgControl?.markAsTouched();
+    fixture.detectChanges();
+    const notes = fixture.debugElement.queryAll(By.css("ion-note"));
+    const hasError = notes.some((n) =>
+      n.nativeElement.textContent.includes("Organization is required."),
+    );
+    expect(hasError).toBeTrue();
+  });
+
+  it("should display contact email validation message when invalid", () => {
+    component.addEmail();
+    const emailGroup = component
+      .getFormArray("contactInformation.emails")
+      .at(0);
+    emailGroup.get("email")?.setValue("");
+    emailGroup.get("email")?.markAsTouched();
+    fixture.detectChanges();
+    const notes = fixture.debugElement.queryAll(By.css("ion-note"));
+    const hasError = notes.some((n) =>
+      n.nativeElement.textContent.includes("Email is required."),
+    );
+    expect(hasError).toBeTrue();
   });
 });


### PR DESCRIPTION
## Summary
- show validation messages for contact info fields
- test that validation messages appear when controls are invalid

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_687bbcfeb3788326b646af61ca85611f