### PR TITLE
Enhance relationship model with roles

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -39,6 +39,14 @@ service cloud.firestore {
         return request.auth != null && request.auth.uid == accountId;
       }
 
+      function isGroupAdmin() {
+        return request.auth != null &&
+          exists(/databases/$(database)/documents/accounts/$(accountId)/relatedAccounts/$(request.auth.uid)) &&
+          get(/databases/$(database)/documents/accounts/$(accountId)/relatedAccounts/$(request.auth.uid)).data.status == 'accepted' &&
+          (get(/databases/$(database)/documents/accounts/$(accountId)/relatedAccounts/$(request.auth.uid)).data.role == 'admin' ||
+           get(/databases/$(database)/documents/accounts/$(accountId)/relatedAccounts/$(request.auth.uid)).data.role == 'moderator');
+      }
+
       // Friends-only access
       function isAcceptedFriend() {
         return (request.auth != null && exists(/databases/$(database)/documents/accounts/$(accountId)/relatedAccounts/$(request.auth.uid))
@@ -66,13 +74,14 @@ service cloud.firestore {
       // Allow read if the user is accessing their own account
       allow read: if (isAccountOwner() || isAcceptedFriend() || isAcceptedGroup() || isPublicGroup() || isPublicUser());
 
-      // General write rule (customize as needed)
-      allow create, write: if isAccountOwner();
+      // General write rule allows owners or group admins/moderators
+      allow create, write: if isAccountOwner() || isGroupAdmin();
     }
 
     // Rules for relatedAccount
     match /accounts/{accountId}/relatedAccounts/{relatedAccountId} {
-      allow create, read, write, delete: if request.auth.uid != null;  // Only authenticated users
+      allow read: if request.auth.uid != null;
+      allow create, write, delete: if isAccountOwner() || isGroupAdmin();
     }
 
     match /accounts/{accountId}/relatedListings/{listingId} {

--- a/functions/src/database/accounts/relatedAccounts/triggers/onCreate/index.ts
+++ b/functions/src/database/accounts/relatedAccounts/triggers/onCreate/index.ts
@@ -49,6 +49,8 @@ export const onCreateRelatedAccount = onDocumentCreated(
       return;
     }
 
+    const requestData = event.data.data();
+
     const accountId = event.params.accountId;
     const relatedAccountId = event.params.relatedAccountId;
 
@@ -96,6 +98,12 @@ export const onCreateRelatedAccount = onDocumentCreated(
         targetData?.type,
       );
 
+      const role =
+        requestData?.role ??
+        (relationship === "member" || relationship === "partner"
+          ? "member"
+          : undefined);
+
       await db
         .collection("accounts")
         .doc(relatedAccountId)
@@ -110,6 +118,7 @@ export const onCreateRelatedAccount = onDocumentCreated(
           type: initiatorData?.type,
           status: "pending",
           relationship,
+          role,
           createdAt: admin.firestore.FieldValue.serverTimestamp(),
           createdBy: accountId,
           lastModifiedAt: admin.firestore.FieldValue.serverTimestamp(),

--- a/functions/src/database/accounts/relatedAccounts/triggers/onUpdate/index.ts
+++ b/functions/src/database/accounts/relatedAccounts/triggers/onUpdate/index.ts
@@ -54,7 +54,8 @@ export const onUpdateRelatedAccount = onDocumentUpdated(
       if (
         // If the status or relationship has changed, update the reciprocal related account document (prevents infinite loop on lastModifiedAt update)
         before.status !== after.status ||
-        before.relationship !== after.relationship
+        before.relationship !== after.relationship ||
+        before.role !== after.role
       ) {
         const reciprocalRelatedAccountRef = db
           .collection("accounts")
@@ -68,13 +69,15 @@ export const onUpdateRelatedAccount = onDocumentUpdated(
         if (
           reciprocalData &&
           (reciprocalData.status !== after.status ||
-            reciprocalData.relationship !== after.relationship)
+            reciprocalData.relationship !== after.relationship ||
+            reciprocalData.role !== after.role)
         ) {
           await reciprocalRelatedAccountRef.update({
             id: accountId,
             accountId: relatedAccountId,
             relationship: after.relationship,
             status: after.status,
+            role: after.role,
             lastModifiedAt: admin.firestore.FieldValue.serverTimestamp(),
             lastModifiedBy: accountId,
           });

--- a/shared/models/account.model.ts
+++ b/shared/models/account.model.ts
@@ -240,7 +240,22 @@ export interface RelatedAccount extends BaseDocument {
   tagline?: string; // Tagline or short description
   type?: "user" | "group"; // Type of the related account
   status?: "pending" | "accepted" | "rejected" | "blocked"; // Relationship status
-  relationship?: "admin" | "friend" | "member" | "partner"; // Details about the relationship (e.g., 'friend', 'member')
+  relationship?:
+    | "admin"
+    | "friend"
+    | "member"
+    | "partner"
+    | "family"
+    | "parent"
+    | "child"
+    | "boss"
+    | "employee"
+    | "volunteer"
+    | "sibling"
+    | "parent-org"
+    | "child-org"
+    | "external"; // Details about the relationship (e.g., 'friend', 'member')
+  role?: "admin" | "moderator" | "member"; // Role within a group
   initiatorId?: string; // ID of the account who initiated the request
   targetId?: string; // ID of the account who received the request
   canAccessContactInfo?: boolean; // Whether the related account can access the contact information

--- a/src/app/modules/account/relatedAccount/pages/list/list.page.html
+++ b/src/app/modules/account/relatedAccount/pages/list/list.page.html
@@ -62,6 +62,38 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                   <h3>{{ relatedAccount.name }}</h3>
                   <p>{{ relatedAccount.tagline }}</p>
                 </ion-label>
+                <ng-container *ngIf="showEditControls$ | async">
+                  <ion-select
+                    [value]="relatedAccount.role"
+                    interface="popover"
+                    (click)="$event.stopPropagation()"
+                    (ionChange)="updateRole(relatedAccount, $event.detail.value)"
+                    style="max-width: 110px; margin-right: 8px"
+                  >
+                    <ion-select-option
+                      *ngFor="let role of roleOptions"
+                      [value]="role"
+                    >
+                      {{ role }}
+                    </ion-select-option>
+                  </ion-select>
+                  <ion-select
+                    [value]="relatedAccount.relationship"
+                    interface="popover"
+                    (click)="$event.stopPropagation()"
+                    (ionChange)="
+                      updateRelationship(relatedAccount, $event.detail.value)
+                    "
+                    style="max-width: 130px"
+                  >
+                    <ion-select-option
+                      *ngFor="let rel of relationshipOptions"
+                      [value]="rel"
+                    >
+                      {{ rel }}
+                    </ion-select-option>
+                  </ion-select>
+                </ng-container>
                 <ion-button
                   slot="end"
                   expand="block"
@@ -110,6 +142,36 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                     <h3>{{ relatedAccount.name }}</h3>
                     <p>{{ relatedAccount.tagline }}</p>
                   </ion-label>
+                  <ng-container *ngIf="showEditControls$ | async">
+                    <ion-select
+                      [value]="relatedAccount.role"
+                      interface="popover"
+                      (click)="$event.stopPropagation()"
+                      (ionChange)="updateRole(relatedAccount, $event.detail.value)"
+                      style="max-width: 110px; margin-right: 8px"
+                    >
+                      <ion-select-option
+                        *ngFor="let role of roleOptions"
+                        [value]="role"
+                        >{{ role }}</ion-select-option
+                      >
+                    </ion-select>
+                    <ion-select
+                      [value]="relatedAccount.relationship"
+                      interface="popover"
+                      (click)="$event.stopPropagation()"
+                      (ionChange)="
+                        updateRelationship(relatedAccount, $event.detail.value)
+                      "
+                      style="max-width: 130px"
+                    >
+                      <ion-select-option
+                        *ngFor="let rel of relationshipOptions"
+                        [value]="rel"
+                        >{{ rel }}</ion-select-option
+                      >
+                    </ion-select>
+                  </ng-container>
                   <ion-button
                     slot="end"
                     expand="block"

--- a/src/app/modules/account/relatedAccount/pages/list/list.page.html
+++ b/src/app/modules/account/relatedAccount/pages/list/list.page.html
@@ -48,8 +48,8 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
             <ion-list>
               <ion-item
                 *ngFor="let relatedAccount of currentList; trackBy: trackById"
-                [routerLink]="getOtherId(relatedAccount) ? '/account/' + getOtherId(relatedAccount) : '#' "
                 button
+                (click)="goToRelatedAccount(getOtherId(relatedAccount))"
               >
                 <ion-thumbnail slot="start">
                   <img
@@ -128,8 +128,8 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
               <ion-list>
                 <ion-item
                   *ngFor="let relatedAccount of pendingList; trackBy: trackById"
-                  [routerLink]="getOtherId(relatedAccount) ? '/account/' + getOtherId(relatedAccount) : '#' "
                   button
+                  (click)="goToRelatedAccount(getOtherId(relatedAccount))"
                 >
                   <ion-thumbnail slot="start">
                     <img

--- a/src/app/modules/account/relatedAccount/pages/list/list.page.html
+++ b/src/app/modules/account/relatedAccount/pages/list/list.page.html
@@ -66,6 +66,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                   <ion-select
                     [value]="relatedAccount.role"
                     interface="popover"
+                    placeholder="Role"
                     (click)="$event.stopPropagation()"
                     (ionChange)="updateRole(relatedAccount, $event.detail.value)"
                     style="max-width: 110px; margin-right: 8px"
@@ -80,6 +81,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                   <ion-select
                     [value]="relatedAccount.relationship"
                     interface="popover"
+                    placeholder="Relationship"
                     (click)="$event.stopPropagation()"
                     (ionChange)="
                       updateRelationship(relatedAccount, $event.detail.value)
@@ -146,6 +148,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                     <ion-select
                       [value]="relatedAccount.role"
                       interface="popover"
+                      placeholder="Role"
                       (click)="$event.stopPropagation()"
                       (ionChange)="updateRole(relatedAccount, $event.detail.value)"
                       style="max-width: 110px; margin-right: 8px"
@@ -159,6 +162,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                     <ion-select
                       [value]="relatedAccount.relationship"
                       interface="popover"
+                      placeholder="Relationship"
                       (click)="$event.stopPropagation()"
                       (ionChange)="
                         updateRelationship(relatedAccount, $event.detail.value)

--- a/src/app/modules/account/relatedAccount/pages/list/list.page.ts
+++ b/src/app/modules/account/relatedAccount/pages/list/list.page.ts
@@ -21,7 +21,7 @@
 
 import {Component, OnInit} from "@angular/core";
 import {Store} from "@ngrx/store";
-import {ActivatedRoute} from "@angular/router";
+import {ActivatedRoute, Router} from "@angular/router";
 import {Observable, combineLatest, of} from "rxjs";
 import {map} from "rxjs/operators";
 import {AuthUser} from "@shared/models/auth-user.model";
@@ -75,6 +75,7 @@ export class ListPage implements OnInit {
 
   constructor(
     private activatedRoute: ActivatedRoute,
+    private router: Router,
     private metaService: MetaService,
     private store: Store,
   ) {
@@ -365,5 +366,15 @@ export class ListPage implements OnInit {
    */
   trackById(index: number, item: Partial<RelatedAccount>): string {
     return item.id ? item.id : index.toString();
+  }
+
+  /**
+   * Navigates to the selected related account.
+   * @param id The account ID to navigate to.
+   */
+  goToRelatedAccount(id: string | null | undefined) {
+    if (id) {
+      this.router.navigate([`/account/${id}`]);
+    }
   }
 }

--- a/src/app/modules/account/relatedAccount/pages/list/list.page.ts
+++ b/src/app/modules/account/relatedAccount/pages/list/list.page.ts
@@ -162,8 +162,12 @@ export class ListPage implements OnInit {
         this.currentUser$,
         this.isGroupAdmin$,
       ]).pipe(
-        map(([account, user, isAdmin]) =>
-          !!account && account.type === "group" && (!!user && (isAdmin || user.uid === account.id)),
+        map(
+          ([account, user, isAdmin]) =>
+            !!account &&
+            account.type === "group" &&
+            !!user &&
+            (isAdmin || user.uid === account.id),
         ),
       );
     }
@@ -272,7 +276,7 @@ export class ListPage implements OnInit {
     this.currentUser$.pipe(take(1)).subscribe((authUser) => {
       if (!authUser?.uid || !request.id || !this.accountId) return;
       const updated: RelatedAccount = {
-        id: request.id,
+        ...(request as RelatedAccount),
         accountId: this.accountId,
         role: role as "admin" | "moderator" | "member",
         lastModifiedBy: authUser.uid,
@@ -290,7 +294,7 @@ export class ListPage implements OnInit {
     this.currentUser$.pipe(take(1)).subscribe((authUser) => {
       if (!authUser?.uid || !request.id || !this.accountId) return;
       const updated: RelatedAccount = {
-        id: request.id,
+        ...(request as RelatedAccount),
         accountId: this.accountId,
         relationship: relationship as any,
         lastModifiedBy: authUser.uid,


### PR DESCRIPTION
## Summary
- support new relationship categories and a role field in RelatedAccount
- default the role in Cloud Functions and sync changes
- restrict updates using role-aware Firestore rules

## Testing
- `npm run test` *(fails: Chrome binary not found)*
- `npm --prefix functions test`

------
https://chatgpt.com/codex/tasks/task_e_687bd504ebe88326aaca83b77d96153c