### PR TITLE
Add group role management

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -43,8 +43,8 @@ service cloud.firestore {
         return request.auth != null &&
           exists(/databases/$(database)/documents/accounts/$(accountId)/relatedAccounts/$(request.auth.uid)) &&
           get(/databases/$(database)/documents/accounts/$(accountId)/relatedAccounts/$(request.auth.uid)).data.status == 'accepted' &&
-          (get(/databases/$(database)/documents/accounts/$(accountId)/relatedAccounts/$(request.auth.uid)).data.role == 'admin' ||
-           get(/databases/$(database)/documents/accounts/$(accountId)/relatedAccounts/$(request.auth.uid)).data.role == 'moderator');
+          (get(/databases/$(database)/documents/accounts/$(accountId)/relatedAccounts/$(request.auth.uid)).data.access == 'admin' ||
+           get(/databases/$(database)/documents/accounts/$(accountId)/relatedAccounts/$(request.auth.uid)).data.access == 'moderator');
       }
 
       // Friends-only access

--- a/functions/src/database/accounts/relatedAccounts/triggers/onCreate/index.ts
+++ b/functions/src/database/accounts/relatedAccounts/triggers/onCreate/index.ts
@@ -98,8 +98,8 @@ export const onCreateRelatedAccount = onDocumentCreated(
         targetData?.type,
       );
 
-      const role =
-        requestData?.role ??
+      const access =
+        requestData?.access ??
         (relationship === "member" || relationship === "partner"
           ? "member"
           : undefined);
@@ -118,7 +118,7 @@ export const onCreateRelatedAccount = onDocumentCreated(
           type: initiatorData?.type,
           status: "pending",
           relationship,
-          role,
+          access,
           createdAt: admin.firestore.FieldValue.serverTimestamp(),
           createdBy: accountId,
           lastModifiedAt: admin.firestore.FieldValue.serverTimestamp(),

--- a/functions/src/database/accounts/relatedAccounts/triggers/onUpdate/index.ts
+++ b/functions/src/database/accounts/relatedAccounts/triggers/onUpdate/index.ts
@@ -55,7 +55,7 @@ export const onUpdateRelatedAccount = onDocumentUpdated(
         // If the status or relationship has changed, update the reciprocal related account document (prevents infinite loop on lastModifiedAt update)
         before.status !== after.status ||
         before.relationship !== after.relationship ||
-        before.role !== after.role
+        before.access !== after.access
       ) {
         const reciprocalRelatedAccountRef = db
           .collection("accounts")
@@ -70,14 +70,14 @@ export const onUpdateRelatedAccount = onDocumentUpdated(
           reciprocalData &&
           (reciprocalData.status !== after.status ||
             reciprocalData.relationship !== after.relationship ||
-            reciprocalData.role !== after.role)
+            reciprocalData.access !== after.access)
         ) {
           await reciprocalRelatedAccountRef.update({
             id: accountId,
             accountId: relatedAccountId,
             relationship: after.relationship,
             status: after.status,
-            role: after.role,
+            access: after.access,
             lastModifiedAt: admin.firestore.FieldValue.serverTimestamp(),
             lastModifiedBy: accountId,
           });

--- a/shared/models/account.model.ts
+++ b/shared/models/account.model.ts
@@ -19,6 +19,7 @@
 ***********************************************************************************************/
 import {BaseDocument} from "./base-document";
 import {GeoPoint, Timestamp} from "firebase/firestore";
+import {GroupRole} from "./group-role.model";
 
 // Define a type for optional and nullable fields
 type Nullable<T> = T | null;
@@ -210,6 +211,10 @@ interface Group {
     groupAdminsManagers: string[]; // Assign initial administrators or managers for the group
     notificationPreferences?: string; // e.g., "Email notifications for new posts, member requests"
   };
+  /**
+   * Custom roles that can be assigned to related accounts
+   */
+  roles?: GroupRole[];
 }
 
 export interface Account extends BaseDocument, Group, User {
@@ -256,6 +261,10 @@ export interface RelatedAccount extends BaseDocument {
     | "child-org"
     | "external"; // Details about the relationship (e.g., 'friend', 'member')
   role?: "admin" | "moderator" | "member"; // Role within a group
+  /**
+   * Reference to a custom group role defined in the parent group
+   */
+  roleId?: string;
   initiatorId?: string; // ID of the account who initiated the request
   targetId?: string; // ID of the account who received the request
   canAccessContactInfo?: boolean; // Whether the related account can access the contact information

--- a/shared/models/account.model.ts
+++ b/shared/models/account.model.ts
@@ -260,7 +260,14 @@ export interface RelatedAccount extends BaseDocument {
     | "parent-org"
     | "child-org"
     | "external"; // Details about the relationship (e.g., 'friend', 'member')
-  role?: "admin" | "moderator" | "member"; // Role within a group
+  /**
+   * Built-in access level within a group
+   */
+  access?: "admin" | "moderator" | "member";
+  /**
+   * Optional custom role name
+   */
+  role?: string;
   /**
    * Reference to a custom group role defined in the parent group
    */

--- a/shared/models/group-role.model.ts
+++ b/shared/models/group-role.model.ts
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ *******************************************************************************/
+// shared/models/group-role.model.ts
+
+export interface GroupRole {
+  id: string;
+  name: string;
+  description?: string;
+  parentRoleId?: string;
+  permissions?: string[];
+}

--- a/src/app/modules/account/account-routing.module.ts
+++ b/src/app/modules/account/account-routing.module.ts
@@ -28,6 +28,7 @@ import {SettingsPage} from "./pages/settings/settings.page";
 import {UsersPage} from "./pages/users/users.page";
 import {ListPage} from "./relatedAccount/pages/list/list.page";
 import {ListingsListPage} from "./relatedListings/pages/listings-list/listings-list.page";
+import {RoleManagementPage} from "./pages/role-management/role-management.page";
 
 const routes: Routes = [
   {
@@ -67,6 +68,11 @@ const routes: Routes = [
   {
     path: ":accountId/related/:listType",
     component: ListPage,
+    canActivate: [AuthGuard],
+  },
+  {
+    path: ":accountId/roles",
+    component: RoleManagementPage,
     canActivate: [AuthGuard],
   },
 ];

--- a/src/app/modules/account/account.module.ts
+++ b/src/app/modules/account/account.module.ts
@@ -55,6 +55,7 @@ import {UsersPage} from "./pages/users/users.page";
 import {ListPage} from "./relatedAccount/pages/list/list.page";
 import {RelatedListingsComponent} from "./pages/details/components/related-listings/related-listings.component";
 import {ListingsListPage} from "./relatedListings/pages/listings-list/listings-list.page";
+import {RoleManagementPage} from "./pages/role-management/role-management.page";
 
 @NgModule({
   declarations: [
@@ -84,6 +85,7 @@ import {ListingsListPage} from "./relatedListings/pages/listings-list/listings-l
     ListingsListPage,
     ListPage,
     RelatedListingsComponent,
+    RoleManagementPage,
   ],
   imports: [
     AccountRoutingModule,

--- a/src/app/modules/account/pages/role-management/role-management.page.html
+++ b/src/app/modules/account/pages/role-management/role-management.page.html
@@ -4,68 +4,121 @@
 </ion-header>
 
 <ion-content>
-  <ng-container *ngIf="roles$ | async as roles">
-    <ion-list>
-      <ion-item *ngFor="let role of roles">
-        <ion-label class="ion-text-wrap" slot="start">
-          <h3>{{ role.name }}</h3>
-          <p>
-            Parent: {{ getParentName(role.parentRoleId, roles) || 'None' }}<br />
-            {{ role.description }}
-          </p>
-        </ion-label>
-        <ion-input
-          [(ngModel)]="role.name"
-          placeholder="Name"
-          (ionBlur)="updateRole(role)"
-        ></ion-input>
-        <ion-input
-          [(ngModel)]="role.description"
-          placeholder="Description"
-          (ionBlur)="updateRole(role)"
-        ></ion-input>
-        <ion-select
-          [(ngModel)]="role.parentRoleId"
-          placeholder="Parent"
-          (ionChange)="updateRole(role)"
-        >
-          <ion-select-option [value]="undefined">None</ion-select-option>
-          <ion-select-option
-            *ngFor="let parent of roles"
-            [value]="parent.id"
-            [disabled]="parent.id === role.id || isDescendant(parent.id, role.id, roles)"
+  <ng-container *ngIf="editableRoles$ | async as roles">
+    <ion-card>
+      <ion-card-header>
+        <ion-card-title>Existing Roles</ion-card-title>
+      </ion-card-header>
+      <ion-card-content>
+        <!-- Column Headers -->
+        <ion-grid>
+          <ion-row
+            class="ion-text-center"
+            style="
+              font-weight: bold;
+              border-bottom: 1px solid var(--ion-color-medium);
+              padding-bottom: 8px;
+              margin-bottom: 8px;
+              color: var(--ion-color-dark);
+            "
           >
-            {{ parent.name }}
-          </ion-select-option>
-        </ion-select>
-        <ion-button slot="end" color="primary" (click)="updateRole(role)">
-          Save
-        </ion-button>
-        <ion-button slot="end" color="danger" (click)="deleteRole(role)">
-          Delete
-        </ion-button>
-      </ion-item>
-    </ion-list>
+            <ion-col align="left" size="4">Current Info</ion-col>
+            <ion-col align="left" size="2">Name</ion-col>
+            <ion-col align="left" size="2">Description</ion-col>
+            <ion-col align="left" size="2">Parent Role</ion-col>
+            <ion-col align="left" size="2">Actions</ion-col>
+          </ion-row>
+        </ion-grid>
 
-    <ion-item>
-      <ion-input
-        placeholder="Role name"
-        [(ngModel)]="newRole.name"
-      ></ion-input>
-      <ion-input
-        placeholder="Description"
-        [(ngModel)]="newRole.description"
-      ></ion-input>
-      <ion-select [(ngModel)]="newRole.parentRoleId" placeholder="Parent">
-        <ion-select-option [value]="undefined">None</ion-select-option>
-        <ion-select-option
-          *ngFor="let parent of roles"
-          [value]="parent.id"
-        >
-          {{ parent.name }}
-        </ion-select-option>
-      </ion-select>
-      <ion-button (click)="addRole()">Add</ion-button>
-    </ion-item>
+        <ion-grid *ngFor="let role of roles">
+          <ion-row style="color: var(--ion-color-dark)">
+            <ion-col size="4">
+              <h3 style="font-weight: bold; color: var(--ion-color-primary)">
+                {{ role.name }}
+              </h3>
+              <p style="color: var(--ion-color-secondary)">
+                Parent: {{ getParentName(role.parentRoleId, roles) || 'None'
+                }}<br />
+                {{ role.description }}
+              </p>
+            </ion-col>
+            <ion-col size="2">
+              <ion-input
+                [(ngModel)]="role.name"
+                placeholder="Name"
+                maxlength="50"
+                (ionBlur)="updateRole(role)"
+              ></ion-input>
+            </ion-col>
+            <ion-col size="2">
+              <ion-input
+                [(ngModel)]="role.description"
+                placeholder="Description"
+                maxlength="150"
+                (ionBlur)="updateRole(role)"
+              ></ion-input>
+            </ion-col>
+            <ion-col size="2">
+              <ion-select
+                [(ngModel)]="role.parentRoleId"
+                placeholder="Parent"
+                (ionChange)="updateRole(role)"
+              >
+                <ion-select-option [value]="undefined">None</ion-select-option>
+                <ion-select-option
+                  *ngFor="let parent of roles"
+                  [value]="parent.id"
+                  [disabled]="parent.id === role.id || isDescendant(parent.id, role.id, roles)"
+                >
+                  {{ parent.name }}
+                </ion-select-option>
+              </ion-select>
+            </ion-col>
+            <ion-col size="2">
+              <ion-button color="danger" (click)="deleteRole(role)">
+                Delete
+              </ion-button>
+            </ion-col>
+          </ion-row>
+        </ion-grid>
+      </ion-card-content>
+    </ion-card>
+
+    <ion-card>
+      <ion-card-header>
+        <ion-card-title>Add New Role</ion-card-title>
+      </ion-card-header>
+      <ion-card-content>
+        <ion-item>
+          <ion-label position="stacked">Role Name</ion-label>
+          <ion-input
+            placeholder="Enter role name"
+            maxlength="50"
+            [(ngModel)]="newRole.name"
+          ></ion-input>
+        </ion-item>
+        <ion-item>
+          <ion-label position="stacked">Description</ion-label>
+          <ion-input
+            placeholder="Enter role description"
+            maxlength="150"
+            [(ngModel)]="newRole.description"
+          ></ion-input>
+        </ion-item>
+        <ion-item>
+          <ion-label position="stacked">Parent Role</ion-label>
+          <ion-select
+            [(ngModel)]="newRole.parentRoleId"
+            placeholder="Select parent role"
+          >
+            <ion-select-option [value]="undefined">None</ion-select-option>
+            <ion-select-option *ngFor="let parent of roles" [value]="parent.id">
+              {{ parent.name }}
+            </ion-select-option>
+          </ion-select>
+        </ion-item>
+        <ion-button expand="block" (click)="addRole()">Add Role</ion-button>
+      </ion-card-content>
+    </ion-card>
   </ng-container>
 </ion-content>

--- a/src/app/modules/account/pages/role-management/role-management.page.html
+++ b/src/app/modules/account/pages/role-management/role-management.page.html
@@ -4,27 +4,59 @@
 </ion-header>
 
 <ion-content>
-  <ion-list>
-    <ion-item *ngFor="let role of roles$ | async">
-      <ion-label>
-        <h2>{{ role.name }}</h2>
-        <p>{{ role.description }}</p>
-      </ion-label>
-      <ion-button slot="end" color="danger" (click)="deleteRole(role)">
-        Delete
-      </ion-button>
-    </ion-item>
-  </ion-list>
+  <ng-container *ngIf="roles$ | async as roles">
+    <ion-list>
+      <ion-item *ngFor="let role of roles">
+        <ion-label style="min-width: 60px" slot="start">{{ role.id }}</ion-label>
+        <ion-input
+          [(ngModel)]="role.name"
+          placeholder="Name"
+          (ionBlur)="updateRole(role)"
+        ></ion-input>
+        <ion-input
+          [(ngModel)]="role.description"
+          placeholder="Description"
+          (ionBlur)="updateRole(role)"
+        ></ion-input>
+        <ion-select
+          [(ngModel)]="role.parentRoleId"
+          placeholder="Parent"
+          (ionChange)="updateRole(role)"
+        >
+          <ion-select-option [value]="undefined">None</ion-select-option>
+          <ion-select-option
+            *ngFor="let parent of roles"
+            [value]="parent.id"
+            [disabled]="parent.id === role.id"
+          >
+            {{ parent.name }}
+          </ion-select-option>
+        </ion-select>
+        <ion-button slot="end" color="danger" (click)="deleteRole(role)">
+          Delete
+        </ion-button>
+      </ion-item>
+    </ion-list>
 
-  <ion-item>
-    <ion-input
-      placeholder="Role name"
-      [(ngModel)]="newRole.name"
-    ></ion-input>
-    <ion-input
-      placeholder="Description"
-      [(ngModel)]="newRole.description"
-    ></ion-input>
-    <ion-button (click)="addRole()">Add</ion-button>
-  </ion-item>
+    <ion-item>
+      <ion-input
+        placeholder="Role name"
+        [(ngModel)]="newRole.name"
+      ></ion-input>
+      <ion-input
+        placeholder="Description"
+        [(ngModel)]="newRole.description"
+      ></ion-input>
+      <ion-select [(ngModel)]="newRole.parentRoleId" placeholder="Parent">
+        <ion-select-option [value]="undefined">None</ion-select-option>
+        <ion-select-option
+          *ngFor="let parent of roles"
+          [value]="parent.id"
+        >
+          {{ parent.name }}
+        </ion-select-option>
+      </ion-select>
+      <ion-button (click)="addRole()">Add</ion-button>
+    </ion-item>
+  </ng-container>
 </ion-content>

--- a/src/app/modules/account/pages/role-management/role-management.page.html
+++ b/src/app/modules/account/pages/role-management/role-management.page.html
@@ -1,0 +1,30 @@
+<!-- role-management.page.html -->
+<ion-header>
+  <app-header [title]="'Group Roles'" [defaultHref]="'../'"></app-header>
+</ion-header>
+
+<ion-content>
+  <ion-list>
+    <ion-item *ngFor="let role of roles$ | async">
+      <ion-label>
+        <h2>{{ role.name }}</h2>
+        <p>{{ role.description }}</p>
+      </ion-label>
+      <ion-button slot="end" color="danger" (click)="deleteRole(role)">
+        Delete
+      </ion-button>
+    </ion-item>
+  </ion-list>
+
+  <ion-item>
+    <ion-input
+      placeholder="Role name"
+      [(ngModel)]="newRole.name"
+    ></ion-input>
+    <ion-input
+      placeholder="Description"
+      [(ngModel)]="newRole.description"
+    ></ion-input>
+    <ion-button (click)="addRole()">Add</ion-button>
+  </ion-item>
+</ion-content>

--- a/src/app/modules/account/pages/role-management/role-management.page.html
+++ b/src/app/modules/account/pages/role-management/role-management.page.html
@@ -38,6 +38,9 @@
             {{ parent.name }}
           </ion-select-option>
         </ion-select>
+        <ion-button slot="end" color="primary" (click)="updateRole(role)">
+          Save
+        </ion-button>
         <ion-button slot="end" color="danger" (click)="deleteRole(role)">
           Delete
         </ion-button>

--- a/src/app/modules/account/pages/role-management/role-management.page.html
+++ b/src/app/modules/account/pages/role-management/role-management.page.html
@@ -7,7 +7,13 @@
   <ng-container *ngIf="roles$ | async as roles">
     <ion-list>
       <ion-item *ngFor="let role of roles">
-        <ion-label style="min-width: 60px" slot="start">{{ role.id }}</ion-label>
+        <ion-label class="ion-text-wrap" slot="start">
+          <h3>{{ role.name }}</h3>
+          <p>
+            Parent: {{ getParentName(role.parentRoleId, roles) || 'None' }}<br />
+            {{ role.description }}
+          </p>
+        </ion-label>
         <ion-input
           [(ngModel)]="role.name"
           placeholder="Name"
@@ -27,7 +33,7 @@
           <ion-select-option
             *ngFor="let parent of roles"
             [value]="parent.id"
-            [disabled]="parent.id === role.id"
+            [disabled]="parent.id === role.id || isDescendant(parent.id, role.id, roles)"
           >
             {{ parent.name }}
           </ion-select-option>

--- a/src/app/modules/account/pages/role-management/role-management.page.spec.ts
+++ b/src/app/modules/account/pages/role-management/role-management.page.spec.ts
@@ -58,4 +58,16 @@ describe("RoleManagementPage", () => {
       }),
     );
   });
+
+  it("should dispatch updateGroupRole on updateRole", () => {
+    const store = TestBed.inject(Store);
+    spyOn(store, "dispatch");
+    const role = {id: "1", name: "Test"};
+    component.updateRole(role as any);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        type: AccountActions.updateGroupRole.type,
+      }),
+    );
+  });
 });

--- a/src/app/modules/account/pages/role-management/role-management.page.spec.ts
+++ b/src/app/modules/account/pages/role-management/role-management.page.spec.ts
@@ -22,6 +22,8 @@
 import {ComponentFixture, TestBed} from "@angular/core/testing";
 import {RoleManagementPage} from "./role-management.page";
 import {provideMockStore} from "@ngrx/store/testing";
+import {Store} from "@ngrx/store";
+import * as AccountActions from "../../../../state/actions/account.actions";
 import {RouterTestingModule} from "@angular/router/testing";
 import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
 
@@ -43,5 +45,17 @@ describe("RoleManagementPage", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should dispatch createGroupRole on addRole", () => {
+    const store = TestBed.inject(Store);
+    spyOn(store, "dispatch");
+    component.newRole = {name: "Test"};
+    component.addRole();
+    expect(store.dispatch).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        type: AccountActions.createGroupRole.type,
+      }),
+    );
   });
 });

--- a/src/app/modules/account/pages/role-management/role-management.page.spec.ts
+++ b/src/app/modules/account/pages/role-management/role-management.page.spec.ts
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ *******************************************************************************/
+// role-management.page.spec.ts
+
+import {ComponentFixture, TestBed} from "@angular/core/testing";
+import {RoleManagementPage} from "./role-management.page";
+import {provideMockStore} from "@ngrx/store/testing";
+import {RouterTestingModule} from "@angular/router/testing";
+import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
+
+describe("RoleManagementPage", () => {
+  let component: RoleManagementPage;
+  let fixture: ComponentFixture<RoleManagementPage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [RoleManagementPage],
+      imports: [RouterTestingModule],
+      providers: [provideMockStore({})],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RoleManagementPage);
+    component = fixture.componentInstance;
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/account/pages/role-management/role-management.page.ts
+++ b/src/app/modules/account/pages/role-management/role-management.page.ts
@@ -82,4 +82,21 @@ export class RoleManagementPage implements OnInit {
       }),
     );
   }
+
+  getParentName(parentId: string | undefined, roles: GroupRole[]): string | undefined {
+    if (!parentId) return undefined;
+    const parent = roles.find((r) => r.id === parentId);
+    return parent?.name;
+  }
+
+  isDescendant(childId: string, ancestorId: string, roles: GroupRole[]): boolean {
+    let current = roles.find((r) => r.id === childId);
+    while (current?.parentRoleId) {
+      if (current.parentRoleId === ancestorId) {
+        return true;
+      }
+      current = roles.find((r) => r.id === current!.parentRoleId);
+    }
+    return false;
+  }
 }

--- a/src/app/modules/account/pages/role-management/role-management.page.ts
+++ b/src/app/modules/account/pages/role-management/role-management.page.ts
@@ -62,14 +62,14 @@ export class RoleManagementPage implements OnInit {
       description: this.newRole.description,
     };
     this.store.dispatch(
-      AccountActions.createGroupRoleSuccess({groupId: this.groupId, role}),
+      AccountActions.createGroupRole({groupId: this.groupId, role}),
     );
     this.newRole = {name: ""};
   }
 
   deleteRole(role: GroupRole) {
     this.store.dispatch(
-      AccountActions.deleteGroupRoleSuccess({
+      AccountActions.deleteGroupRole({
         groupId: this.groupId,
         roleId: role.id,
       }),

--- a/src/app/modules/account/pages/role-management/role-management.page.ts
+++ b/src/app/modules/account/pages/role-management/role-management.page.ts
@@ -89,14 +89,17 @@ export class RoleManagementPage implements OnInit {
     return parent?.name;
   }
 
-  isDescendant(childId: string, ancestorId: string, roles: GroupRole[]): boolean {
-    let current = roles.find((r) => r.id === childId);
-    while (current?.parentRoleId) {
-      if (current.parentRoleId === ancestorId) {
-        return true;
-      }
-      current = roles.find((r) => r.id === current!.parentRoleId);
-    }
-    return false;
+  isDescendant(
+    childId: string,
+    ancestorId: string,
+    roles: GroupRole[],
+    visited: Set<string> = new Set(),
+  ): boolean {
+    if (visited.has(childId)) return false;
+    visited.add(childId);
+    const child = roles.find((r) => r.id === childId);
+    if (!child || !child.parentRoleId) return false;
+    if (child.parentRoleId === ancestorId) return true;
+    return this.isDescendant(child.parentRoleId, ancestorId, roles, visited);
   }
 }

--- a/src/app/modules/account/pages/role-management/role-management.page.ts
+++ b/src/app/modules/account/pages/role-management/role-management.page.ts
@@ -40,7 +40,7 @@ export class RoleManagementPage implements OnInit {
   roles$!: Observable<GroupRole[]>;
   loading$ = this.store.select(selectAccountLoading);
 
-  newRole: Partial<GroupRole> = {name: ""};
+  newRole: Partial<GroupRole> = {name: "", parentRoleId: undefined};
 
   constructor(
     private route: ActivatedRoute,
@@ -60,11 +60,18 @@ export class RoleManagementPage implements OnInit {
       id: Date.now().toString(),
       name: this.newRole.name!,
       description: this.newRole.description,
+      parentRoleId: this.newRole.parentRoleId,
     };
     this.store.dispatch(
       AccountActions.createGroupRole({groupId: this.groupId, role}),
     );
-    this.newRole = {name: ""};
+    this.newRole = {name: "", parentRoleId: undefined};
+  }
+
+  updateRole(role: GroupRole) {
+    this.store.dispatch(
+      AccountActions.updateGroupRole({groupId: this.groupId, role}),
+    );
   }
 
   deleteRole(role: GroupRole) {

--- a/src/app/modules/account/pages/role-management/role-management.page.ts
+++ b/src/app/modules/account/pages/role-management/role-management.page.ts
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ *******************************************************************************/
+// role-management.page.ts
+
+import {Component, OnInit} from "@angular/core";
+import {ActivatedRoute} from "@angular/router";
+import {Store} from "@ngrx/store";
+import {Observable} from "rxjs";
+import {GroupRole} from "@shared/models/group-role.model";
+import * as AccountActions from "../../../../state/actions/account.actions";
+import {
+  selectGroupRolesByGroupId,
+  selectAccountLoading,
+} from "../../../../state/selectors/account.selectors";
+
+@Component({
+  selector: "app-role-management",
+  templateUrl: "./role-management.page.html",
+  styleUrls: ["./role-management.page.scss"],
+})
+export class RoleManagementPage implements OnInit {
+  groupId!: string;
+  roles$!: Observable<GroupRole[]>;
+  loading$ = this.store.select(selectAccountLoading);
+
+  newRole: Partial<GroupRole> = {name: ""};
+
+  constructor(
+    private route: ActivatedRoute,
+    private store: Store,
+  ) {
+    this.groupId = this.route.snapshot.paramMap.get("accountId") || "";
+  }
+
+  ngOnInit() {
+    this.roles$ = this.store.select(selectGroupRolesByGroupId(this.groupId));
+    this.store.dispatch(AccountActions.loadGroupRoles({groupId: this.groupId}));
+  }
+
+  addRole() {
+    if (!this.newRole.name) return;
+    const role: GroupRole = {
+      id: Date.now().toString(),
+      name: this.newRole.name!,
+      description: this.newRole.description,
+    };
+    this.store.dispatch(
+      AccountActions.createGroupRoleSuccess({groupId: this.groupId, role}),
+    );
+    this.newRole = {name: ""};
+  }
+
+  deleteRole(role: GroupRole) {
+    this.store.dispatch(
+      AccountActions.deleteGroupRoleSuccess({
+        groupId: this.groupId,
+        roleId: role.id,
+      }),
+    );
+  }
+}

--- a/src/app/modules/account/relatedAccount/pages/list/list.page.html
+++ b/src/app/modules/account/relatedAccount/pages/list/list.page.html
@@ -29,7 +29,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
 
 <ion-content [fullscreen]="true">
   <ion-button
-    *ngIf="(isGroupAdmin$ | async)"
+    *ngIf="(canManageRoles$ | async)"
     [routerLink]="['../roles']"
     style="float: right; margin: 8px"
   >
@@ -47,7 +47,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
               async)?.toLowerCase() }}
             </ion-card-subtitle>
             <ion-button
-              *ngIf="(isGroupAdmin$ | async)"
+              *ngIf="(canManageRoles$ | async)"
               slot="end"
               fill="clear"
               size="small"

--- a/src/app/modules/account/relatedAccount/pages/list/list.page.html
+++ b/src/app/modules/account/relatedAccount/pages/list/list.page.html
@@ -39,6 +39,15 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
               {{ (currentRelatedAccountsList$ | async)?.length }} {{ (title$ |
               async)?.toLowerCase() }}
             </ion-card-subtitle>
+            <ion-button
+              *ngIf="(isGroupAdmin$ | async)"
+              slot="end"
+              fill="clear"
+              size="small"
+              [routerLink]="['../roles']"
+            >
+              Manage Roles
+            </ion-button>
           </ion-card-header>
 
           <!-- Unwrap currentRelatedAccountsList$ -->
@@ -64,11 +73,11 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                 </ion-label>
                 <ng-container *ngIf="showEditControls$ | async">
                   <ion-select
-                    [value]="relatedAccount.roleId || relatedAccount.access"
+                    [value]="relatedAccount.access"
                     interface="popover"
-                    placeholder="Role"
+                    placeholder="Access"
                     (click)="$event.stopPropagation()"
-                    (ionChange)="updateRole(relatedAccount, $event.detail.value)"
+                    (ionChange)="updateAccess(relatedAccount, $event.detail.value)"
                     style="max-width: 110px; margin-right: 8px"
                   >
                     <ion-select-option
@@ -77,6 +86,15 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                     >
                       {{ role }}
                     </ion-select-option>
+                  </ion-select>
+                  <ion-select
+                    [value]="relatedAccount.roleId"
+                    interface="popover"
+                    placeholder="Role"
+                    (click)="$event.stopPropagation()"
+                    (ionChange)="updateRole(relatedAccount, $event.detail.value)"
+                    style="max-width: 110px; margin-right: 8px"
+                  >
                     <ion-select-option
                       *ngFor="let role of customRoles$ | async"
                       [value]="role.id"
@@ -151,12 +169,12 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                     <p>{{ relatedAccount.tagline }}</p>
                   </ion-label>
                   <ng-container *ngIf="showEditControls$ | async">
-                    <ion-select
-                      [value]="relatedAccount.roleId || relatedAccount.access"
+                  <ion-select
+                      [value]="relatedAccount.access"
                       interface="popover"
-                      placeholder="Role"
+                      placeholder="Access"
                       (click)="$event.stopPropagation()"
-                      (ionChange)="updateRole(relatedAccount, $event.detail.value)"
+                      (ionChange)="updateAccess(relatedAccount, $event.detail.value)"
                       style="max-width: 110px; margin-right: 8px"
                     >
                       <ion-select-option
@@ -164,6 +182,15 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                         [value]="role"
                         >{{ role }}</ion-select-option
                       >
+                    </ion-select>
+                    <ion-select
+                      [value]="relatedAccount.roleId"
+                      interface="popover"
+                      placeholder="Role"
+                      (click)="$event.stopPropagation()"
+                      (ionChange)="updateRole(relatedAccount, $event.detail.value)"
+                      style="max-width: 110px; margin-right: 8px"
+                    >
                       <ion-select-option
                         *ngFor="let role of customRoles$ | async"
                         [value]="role.id"

--- a/src/app/modules/account/relatedAccount/pages/list/list.page.html
+++ b/src/app/modules/account/relatedAccount/pages/list/list.page.html
@@ -28,6 +28,13 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
 </ion-header>
 
 <ion-content [fullscreen]="true">
+  <ion-button
+    *ngIf="(isGroupAdmin$ | async)"
+    [routerLink]="['../roles']"
+    style="float: right; margin: 8px"
+  >
+    Manage Roles
+  </ion-button>
   <ion-grid>
     <ion-row>
       <ion-col>

--- a/src/app/modules/account/relatedAccount/pages/list/list.page.html
+++ b/src/app/modules/account/relatedAccount/pages/list/list.page.html
@@ -64,7 +64,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                 </ion-label>
                 <ng-container *ngIf="showEditControls$ | async">
                   <ion-select
-                    [value]="relatedAccount.role"
+                    [value]="relatedAccount.roleId"
                     interface="popover"
                     placeholder="Role"
                     (click)="$event.stopPropagation()"
@@ -76,6 +76,12 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                       [value]="role"
                     >
                       {{ role }}
+                    </ion-select-option>
+                    <ion-select-option
+                      *ngFor="let role of customRoles$ | async"
+                      [value]="role.id"
+                    >
+                      {{ role.name }}
                     </ion-select-option>
                   </ion-select>
                   <ion-select
@@ -146,7 +152,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                   </ion-label>
                   <ng-container *ngIf="showEditControls$ | async">
                     <ion-select
-                      [value]="relatedAccount.role"
+                      [value]="relatedAccount.roleId"
                       interface="popover"
                       placeholder="Role"
                       (click)="$event.stopPropagation()"
@@ -157,6 +163,11 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                         *ngFor="let role of roleOptions"
                         [value]="role"
                         >{{ role }}</ion-select-option
+                      >
+                      <ion-select-option
+                        *ngFor="let role of customRoles$ | async"
+                        [value]="role.id"
+                        >{{ role.name }}</ion-select-option
                       >
                     </ion-select>
                     <ion-select

--- a/src/app/modules/account/relatedAccount/pages/list/list.page.html
+++ b/src/app/modules/account/relatedAccount/pages/list/list.page.html
@@ -28,13 +28,6 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
 </ion-header>
 
 <ion-content [fullscreen]="true">
-  <ion-button
-    *ngIf="(canManageRoles$ | async)"
-    [routerLink]="['../roles']"
-    style="float: right; margin: 8px"
-  >
-    Manage Roles
-  </ion-button>
   <ion-grid>
     <ion-row>
       <ion-col>
@@ -48,10 +41,9 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
             </ion-card-subtitle>
             <ion-button
               *ngIf="(canManageRoles$ | async)"
-              slot="end"
               fill="clear"
               size="small"
-              [routerLink]="['../roles']"
+              (click)="navigateToRoles()"
             >
               Manage Roles
             </ion-button>
@@ -110,6 +102,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                     </ion-select-option>
                   </ion-select>
                   <ion-select
+                    disabled="true"
                     [value]="relatedAccount.relationship"
                     interface="popover"
                     placeholder="Relationship"
@@ -176,7 +169,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                     <p>{{ relatedAccount.tagline }}</p>
                   </ion-label>
                   <ng-container *ngIf="showEditControls$ | async">
-                  <ion-select
+                    <ion-select
                       [value]="relatedAccount.access"
                       interface="popover"
                       placeholder="Access"
@@ -205,6 +198,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                       >
                     </ion-select>
                     <ion-select
+                      disabled="true"
                       [value]="relatedAccount.relationship"
                       interface="popover"
                       placeholder="Relationship"

--- a/src/app/modules/account/relatedAccount/pages/list/list.page.html
+++ b/src/app/modules/account/relatedAccount/pages/list/list.page.html
@@ -64,7 +64,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                 </ion-label>
                 <ng-container *ngIf="showEditControls$ | async">
                   <ion-select
-                    [value]="relatedAccount.roleId"
+                    [value]="relatedAccount.roleId || relatedAccount.access"
                     interface="popover"
                     placeholder="Role"
                     (click)="$event.stopPropagation()"
@@ -72,7 +72,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                     style="max-width: 110px; margin-right: 8px"
                   >
                     <ion-select-option
-                      *ngFor="let role of roleOptions"
+                      *ngFor="let role of accessOptions"
                       [value]="role"
                     >
                       {{ role }}
@@ -152,7 +152,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                   </ion-label>
                   <ng-container *ngIf="showEditControls$ | async">
                     <ion-select
-                      [value]="relatedAccount.roleId"
+                      [value]="relatedAccount.roleId || relatedAccount.access"
                       interface="popover"
                       placeholder="Role"
                       (click)="$event.stopPropagation()"
@@ -160,7 +160,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                       style="max-width: 110px; margin-right: 8px"
                     >
                       <ion-select-option
-                        *ngFor="let role of roleOptions"
+                        *ngFor="let role of accessOptions"
                         [value]="role"
                         >{{ role }}</ion-select-option
                       >

--- a/src/app/modules/account/relatedAccount/pages/list/list.page.html
+++ b/src/app/modules/account/relatedAccount/pages/list/list.page.html
@@ -70,7 +70,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                   <h3>{{ relatedAccount.name }}</h3>
                   <p>{{ relatedAccount.tagline }}</p>
                 </ion-label>
-                <ng-container *ngIf="showEditControls$ | async">
+                <ng-container *ngIf="showAccessControls$ | async">
                   <ion-select
                     [value]="relatedAccount.access"
                     interface="popover"
@@ -86,6 +86,8 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                       {{ role }}
                     </ion-select-option>
                   </ion-select>
+                </ng-container>
+                <ng-container *ngIf="showAccessControls$ | async">
                   <ion-select
                     [value]="relatedAccount.roleId"
                     interface="popover"
@@ -101,25 +103,25 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                       {{ role.name }}
                     </ion-select-option>
                   </ion-select>
-                  <ion-select
-                    disabled="true"
-                    [value]="relatedAccount.relationship"
-                    interface="popover"
-                    placeholder="Relationship"
-                    (click)="$event.stopPropagation()"
-                    (ionChange)="
+                </ng-container>
+                <ion-select
+                  disabled="true"
+                  [value]="relatedAccount.relationship"
+                  interface="popover"
+                  placeholder="Relationship"
+                  (click)="$event.stopPropagation()"
+                  (ionChange)="
                       updateRelationship(relatedAccount, $event.detail.value)
                     "
-                    style="max-width: 130px"
+                  style="max-width: 130px"
+                >
+                  <ion-select-option
+                    *ngFor="let rel of relationshipOptions"
+                    [value]="rel"
                   >
-                    <ion-select-option
-                      *ngFor="let rel of relationshipOptions"
-                      [value]="rel"
-                    >
-                      {{ rel }}
-                    </ion-select-option>
-                  </ion-select>
-                </ng-container>
+                    {{ rel }}
+                  </ion-select-option>
+                </ion-select>
                 <ion-button
                   slot="end"
                   expand="block"
@@ -168,7 +170,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                     <h3>{{ relatedAccount.name }}</h3>
                     <p>{{ relatedAccount.tagline }}</p>
                   </ion-label>
-                  <ng-container *ngIf="showEditControls$ | async">
+                  <ng-container *ngIf="showAccessControls$ | async">
                     <ion-select
                       [value]="relatedAccount.access"
                       interface="popover"
@@ -183,6 +185,8 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                         >{{ role }}</ion-select-option
                       >
                     </ion-select>
+                  </ng-container>
+                  <ng-container *ngIf="showRoleControls$ | async">
                     <ion-select
                       [value]="relatedAccount.roleId"
                       interface="popover"
@@ -197,24 +201,24 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                         >{{ role.name }}</ion-select-option
                       >
                     </ion-select>
-                    <ion-select
-                      disabled="true"
-                      [value]="relatedAccount.relationship"
-                      interface="popover"
-                      placeholder="Relationship"
-                      (click)="$event.stopPropagation()"
-                      (ionChange)="
+                  </ng-container>
+                  <ion-select
+                    disabled="true"
+                    [value]="relatedAccount.relationship"
+                    interface="popover"
+                    placeholder="Relationship"
+                    (click)="$event.stopPropagation()"
+                    (ionChange)="
                         updateRelationship(relatedAccount, $event.detail.value)
                       "
-                      style="max-width: 130px"
+                    style="max-width: 130px"
+                  >
+                    <ion-select-option
+                      *ngFor="let rel of relationshipOptions"
+                      [value]="rel"
+                      >{{ rel }}</ion-select-option
                     >
-                      <ion-select-option
-                        *ngFor="let rel of relationshipOptions"
-                        [value]="rel"
-                        >{{ rel }}</ion-select-option
-                      >
-                    </ion-select>
-                  </ng-container>
+                  </ion-select>
                   <ion-button
                     slot="end"
                     expand="block"

--- a/src/app/modules/account/relatedAccount/pages/list/list.page.ts
+++ b/src/app/modules/account/relatedAccount/pages/list/list.page.ts
@@ -282,16 +282,31 @@ export class ListPage implements OnInit {
     );
   }
 
-  updateRole(request: Partial<RelatedAccount>, roleValue: string) {
+  updateAccess(request: Partial<RelatedAccount>, access: "admin" | "moderator" | "member") {
     this.currentUser$.pipe(take(1)).subscribe((authUser) => {
       if (!authUser?.uid || !request.id || !this.accountId) return;
-      const isAccess = this.accessOptions.includes(roleValue as any);
       const updated: RelatedAccount = {
         ...(request as RelatedAccount),
         accountId: this.accountId,
-        roleId: isAccess ? undefined : roleValue,
-        access: isAccess ? (roleValue as any) : request.access,
-        role: request.role,
+        access: access,
+        lastModifiedBy: authUser.uid,
+      };
+      this.store.dispatch(
+        AccountActions.updateRelatedAccount({
+          accountId: this.accountId!,
+          relatedAccount: updated,
+        }),
+      );
+    });
+  }
+
+  updateRole(request: Partial<RelatedAccount>, roleId: string) {
+    this.currentUser$.pipe(take(1)).subscribe((authUser) => {
+      if (!authUser?.uid || !request.id || !this.accountId) return;
+      const updated: RelatedAccount = {
+        ...(request as RelatedAccount),
+        accountId: this.accountId,
+        roleId,
         lastModifiedBy: authUser.uid,
       };
       this.store.dispatch(

--- a/src/app/modules/account/relatedAccount/pages/list/list.page.ts
+++ b/src/app/modules/account/relatedAccount/pages/list/list.page.ts
@@ -56,6 +56,7 @@ export class ListPage implements OnInit {
   isOwner$!: Observable<boolean>;
   title$!: Observable<string>;
   isGroupAdmin$!: Observable<boolean>;
+  canManageRoles$!: Observable<boolean>;
   showEditControls$!: Observable<boolean>;
   accessOptions = ["admin", "moderator", "member"] as const;
   customRoles$!: Observable<GroupRole[]>;
@@ -159,6 +160,11 @@ export class ListPage implements OnInit {
           );
         }),
       );
+
+      this.canManageRoles$ = combineLatest([
+        this.isGroupAdmin$,
+        this.isOwner$,
+      ]).pipe(map(([admin, owner]) => admin || owner));
 
       this.showEditControls$ = combineLatest([
         this.account$,

--- a/src/app/modules/account/relatedAccount/pages/list/list.page.ts
+++ b/src/app/modules/account/relatedAccount/pages/list/list.page.ts
@@ -57,7 +57,7 @@ export class ListPage implements OnInit {
   title$!: Observable<string>;
   isGroupAdmin$!: Observable<boolean>;
   showEditControls$!: Observable<boolean>;
-  roleOptions = ["admin", "moderator", "member"] as const;
+  accessOptions = ["admin", "moderator", "member"] as const;
   customRoles$!: Observable<GroupRole[]>;
   relationshipOptions = [
     "admin",
@@ -155,7 +155,7 @@ export class ListPage implements OnInit {
           const rel = relatedAccounts.find((ra) => ra.id === currentUser.uid);
           return (
             rel?.status === "accepted" &&
-            (rel.role === "admin" || rel.role === "moderator")
+            (rel.access === "admin" || rel.access === "moderator")
           );
         }),
       );
@@ -282,16 +282,16 @@ export class ListPage implements OnInit {
     );
   }
 
-  updateRole(request: Partial<RelatedAccount>, roleId: string) {
+  updateRole(request: Partial<RelatedAccount>, roleValue: string) {
     this.currentUser$.pipe(take(1)).subscribe((authUser) => {
       if (!authUser?.uid || !request.id || !this.accountId) return;
+      const isAccess = this.accessOptions.includes(roleValue as any);
       const updated: RelatedAccount = {
         ...(request as RelatedAccount),
         accountId: this.accountId,
-        roleId,
-        role: this.roleOptions.includes(roleId as any)
-          ? (roleId as any)
-          : request.role,
+        roleId: isAccess ? undefined : roleValue,
+        access: isAccess ? (roleValue as any) : request.access,
+        role: request.role,
         lastModifiedBy: authUser.uid,
       };
       this.store.dispatch(

--- a/src/app/modules/account/relatedAccount/pages/list/list.page.ts
+++ b/src/app/modules/account/relatedAccount/pages/list/list.page.ts
@@ -57,7 +57,8 @@ export class ListPage implements OnInit {
   title$!: Observable<string>;
   isGroupAdmin$!: Observable<boolean>;
   canManageRoles$!: Observable<boolean>;
-  showEditControls$!: Observable<boolean>;
+  showAccessControls$!: Observable<boolean>;
+  showRoleControls$!: Observable<boolean>;
   accessOptions = ["admin", "moderator", "member"] as const;
   customRoles$!: Observable<GroupRole[]>;
   relationshipOptions = ["friend", "member", "partner", "family"] as const;
@@ -151,7 +152,7 @@ export class ListPage implements OnInit {
         this.isOwner$,
       ]).pipe(map(([admin, owner]) => admin || owner));
 
-      this.showEditControls$ = combineLatest([
+      this.showAccessControls$ = combineLatest([
         this.account$,
         this.currentUser$,
         this.isGroupAdmin$,
@@ -162,6 +163,15 @@ export class ListPage implements OnInit {
             account.type === "group" &&
             !!user &&
             (isAdmin || user.uid === account.id),
+        ),
+      );
+
+      this.showRoleControls$ = combineLatest([
+        this.account$,
+        this.currentUser$,
+      ]).pipe(
+        map(
+          ([account, user]) => !!account && !!user && user.uid === account.id,
         ),
       );
 

--- a/src/app/modules/account/relatedAccount/pages/list/list.page.ts
+++ b/src/app/modules/account/relatedAccount/pages/list/list.page.ts
@@ -60,22 +60,7 @@ export class ListPage implements OnInit {
   showEditControls$!: Observable<boolean>;
   accessOptions = ["admin", "moderator", "member"] as const;
   customRoles$!: Observable<GroupRole[]>;
-  relationshipOptions = [
-    "admin",
-    "friend",
-    "member",
-    "partner",
-    "family",
-    "parent",
-    "child",
-    "boss",
-    "employee",
-    "volunteer",
-    "sibling",
-    "parent-org",
-    "child-org",
-    "external",
-  ] as const;
+  relationshipOptions = ["friend", "member", "partner", "family"] as const;
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -288,7 +273,10 @@ export class ListPage implements OnInit {
     );
   }
 
-  updateAccess(request: Partial<RelatedAccount>, access: "admin" | "moderator" | "member") {
+  updateAccess(
+    request: Partial<RelatedAccount>,
+    access: "admin" | "moderator" | "member",
+  ) {
     this.currentUser$.pipe(take(1)).subscribe((authUser) => {
       if (!authUser?.uid || !request.id || !this.accountId) return;
       const updated: RelatedAccount = {
@@ -413,6 +401,15 @@ export class ListPage implements OnInit {
   goToRelatedAccount(id: string | null | undefined) {
     if (id) {
       this.router.navigate([`/account/${id}`]);
+    }
+  }
+
+  /**
+   * Navigates to the roles management page.
+   */
+  navigateToRoles() {
+    if (this.accountId) {
+      this.router.navigate([`/account/${this.accountId}/roles`]);
     }
   }
 }

--- a/src/app/modules/listing/relatedAccount/pages/applicants/applicants.page.spec.ts
+++ b/src/app/modules/listing/relatedAccount/pages/applicants/applicants.page.spec.ts
@@ -149,12 +149,14 @@ describe("ApplicantsPage", () => {
     const accountsState: AccountState = accountAdapter.getInitialState({
       relatedAccounts: {},
       relatedListings: {},
+      groupRoles: {},
       selectedAccountId: null,
       loading: false,
       error: null,
       accountsLastUpdated: null,
       relatedAccountsLastUpdated: {},
       relatedListingsLastUpdated: {},
+      groupRolesLastUpdated: {},
     });
 
     return {

--- a/src/app/state/actions/account.actions.ts
+++ b/src/app/state/actions/account.actions.ts
@@ -21,6 +21,7 @@
 
 import {createAction, props} from "@ngrx/store";
 import {Account, RelatedAccount} from "@shared/models/account.model";
+import {GroupRole} from "@shared/models/group-role.model";
 import {RelatedListing} from "@shared/models/related-listing.model";
 
 export const clearAccountsState = createAction("[Account] Clear Accounts");
@@ -218,5 +219,66 @@ export const deleteRelatedListingSuccess = createAction(
 
 export const deleteRelatedListingFailure = createAction(
   "[Account] Delete Related Listing Failure",
+  props<{error: any}>(),
+);
+
+// Group Roles Management
+export const loadGroupRoles = createAction(
+  "[Account] Load Group Roles",
+  props<{groupId: string}>(),
+);
+
+export const loadGroupRolesSuccess = createAction(
+  "[Account] Load Group Roles Success",
+  props<{groupId: string; roles: GroupRole[]}>(),
+);
+
+export const loadGroupRolesFailure = createAction(
+  "[Account] Load Group Roles Failure",
+  props<{error: any}>(),
+);
+
+export const createGroupRole = createAction(
+  "[Account] Create Group Role",
+  props<{groupId: string; role: GroupRole}>(),
+);
+
+export const createGroupRoleSuccess = createAction(
+  "[Account] Create Group Role Success",
+  props<{groupId: string; role: GroupRole}>(),
+);
+
+export const createGroupRoleFailure = createAction(
+  "[Account] Create Group Role Failure",
+  props<{error: any}>(),
+);
+
+export const updateGroupRole = createAction(
+  "[Account] Update Group Role",
+  props<{groupId: string; role: GroupRole}>(),
+);
+
+export const updateGroupRoleSuccess = createAction(
+  "[Account] Update Group Role Success",
+  props<{groupId: string; role: GroupRole}>(),
+);
+
+export const updateGroupRoleFailure = createAction(
+  "[Account] Update Group Role Failure",
+  props<{error: any}>(),
+);
+
+export const deleteGroupRole = createAction(
+  "[Account] Delete Group Role",
+  props<{groupId: string; roleId: string}>(),
+);
+
+export const deleteGroupRoleSuccess = createAction(
+  "[Account] Delete Group Role Success",
+  props<{groupId: string; roleId: string}>(),
+);
+
+export const deleteGroupRoleFailure = createAction(
+  "[Account] Delete Group Role Failure",
   props<{error: any}>(),
 );

--- a/src/app/state/selectors/account.selectors.ts
+++ b/src/app/state/selectors/account.selectors.ts
@@ -140,6 +140,18 @@ export const selectRelatedListingsLastUpdated = (accountId: string) =>
     (state) => state.relatedListingsLastUpdated[accountId] || null,
   );
 
+export const selectGroupRolesByGroupId = (groupId: string) =>
+  createSelector(
+    selectAccountState,
+    (state) => state.groupRoles[groupId] || [],
+  );
+
+export const selectGroupRolesLastUpdated = (groupId: string) =>
+  createSelector(
+    selectAccountState,
+    (state) => state.groupRolesLastUpdated[groupId] || null,
+  );
+
 export const selectAreAccountsFresh = createSelector(
   selectAccountsLastUpdated,
   (accountsLastUpdated) => !isStale(accountsLastUpdated, ACCOUNTS_TTL),
@@ -157,4 +169,10 @@ export const selectAreRelatedListingsFresh = (accountId: string) =>
     selectRelatedListingsLastUpdated(accountId),
     (relatedListingsLastUpdated) =>
       !isStale(relatedListingsLastUpdated, RELATED_LISTINGS_TTL),
+  );
+
+export const selectAreGroupRolesFresh = (groupId: string) =>
+  createSelector(
+    selectGroupRolesLastUpdated(groupId),
+    (groupRolesLastUpdated) => !isStale(groupRolesLastUpdated, ACCOUNTS_TTL),
   );


### PR DESCRIPTION
## Summary
- add `GroupRole` model
- link custom roles to accounts and related accounts
- update NgRx actions, reducer and selectors for group roles
- add role management page
- expose group role IDs in member list
- update unit tests for new AccountState fields

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_687c1177adc88326b0a72a4ef4c2fc29