### PR TITLE
Add Google Calendar integration

### DIFF
--- a/shared/models/account.model.ts
+++ b/shared/models/account.model.ts
@@ -60,6 +60,8 @@ interface GroupSpecific {
   groupType?: string;
   groupObjectivesMissionStatement?: string;
   groupHistoryBackground?: string;
+  /** Public Google Calendar embed or share URL */
+  googleCalendarUrl?: string;
   // faqs?: string[]; // Optional, for common queries related to the group
 }
 

--- a/src/app/modules/account/account.module.ts
+++ b/src/app/modules/account/account.module.ts
@@ -56,6 +56,7 @@ import {ListPage} from "./relatedAccount/pages/list/list.page";
 import {RelatedListingsComponent} from "./pages/details/components/related-listings/related-listings.component";
 import {ListingsListPage} from "./relatedListings/pages/listings-list/listings-list.page";
 import {RoleManagementPage} from "./pages/role-management/role-management.page";
+import {SafeUrlPipe} from "../../shared/pipes/safe-url.pipe";
 
 @NgModule({
   declarations: [
@@ -86,6 +87,7 @@ import {RoleManagementPage} from "./pages/role-management/role-management.page";
     ListPage,
     RelatedListingsComponent,
     RoleManagementPage,
+    SafeUrlPipe,
   ],
   imports: [
     AccountRoutingModule,

--- a/src/app/modules/account/pages/details/components/profile/profile.component.html
+++ b/src/app/modules/account/pages/details/components/profile/profile.component.html
@@ -58,5 +58,19 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
         </ion-col>
       </ion-row>
     </ion-grid>
+    <div
+      class="info-block"
+      *ngIf="account.type === 'group' && account.groupDetails?.googleCalendarUrl"
+    >
+      <h2>Upcoming Events</h2>
+      <iframe
+        [src]="account.groupDetails?.googleCalendarUrl | safeUrl"
+        style="border:0"
+        width="100%"
+        height="600"
+        frameborder="0"
+        scrolling="no"
+      ></iframe>
+    </div>
   </ion-card-content>
 </ion-card>

--- a/src/app/modules/account/pages/edit/components/basic-info-form/basic-info-form.component.html
+++ b/src/app/modules/account/pages/edit/components/basic-info-form/basic-info-form.component.html
@@ -89,6 +89,16 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
           </ion-select>
         </ion-col>
       </ion-row>
+      <ion-row *ngIf="account?.type === 'group'" formGroupName="groupDetails">
+        <ion-col>
+          <ion-input
+            label="Google Calendar URL"
+            label-placement="stacked"
+            formControlName="googleCalendarUrl"
+            fill="outline"
+          ></ion-input>
+        </ion-col>
+      </ion-row>
       <ion-row>
         <ion-col>
           <!-- <ion-label position="stacked">Description</ion-label> -->

--- a/src/app/modules/account/pages/edit/components/basic-info-form/basic-info-form.component.ts
+++ b/src/app/modules/account/pages/edit/components/basic-info-form/basic-info-form.component.ts
@@ -47,6 +47,7 @@ export class BasicInfoFormComponent implements OnChanges {
       webLinks: this.fb.array([this.createWebLinkFormGroup()]),
       groupDetails: this.fb.group({
         groupType: [""],
+        googleCalendarUrl: [""],
       }),
     });
   }
@@ -142,6 +143,9 @@ export class BasicInfoFormComponent implements OnChanges {
       name: this.account.name,
       description: this.account.description,
       tagline: this.account.tagline,
+      groupDetails: {
+        googleCalendarUrl: this.account.groupDetails?.googleCalendarUrl,
+      },
     });
 
     if (
@@ -151,6 +155,9 @@ export class BasicInfoFormComponent implements OnChanges {
       this.basicInfoForm
         .get("groupDetails.groupType")
         ?.setValue(this.account.groupDetails?.groupType);
+      this.basicInfoForm
+        .get("groupDetails.googleCalendarUrl")
+        ?.setValue(this.account.groupDetails?.googleCalendarUrl);
     }
   }
 

--- a/src/app/modules/account/pages/registration/components/group-registration/group-registration.component.html
+++ b/src/app/modules/account/pages/registration/components/group-registration/group-registration.component.html
@@ -106,14 +106,24 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
                     <ion-select-option value="Government"
                       >Government</ion-select-option
                     >
-                    <ion-select-option value="Other">Other</ion-select-option>
-                  </ion-select>
-                </ion-col>
-              </ion-row>
+                <ion-select-option value="Other">Other</ion-select-option>
+              </ion-select>
             </ion-col>
+          </ion-row>
+          <ion-row>
             <ion-col>
-              <ion-row>
-                <ion-col>
+              <ion-input
+                label="Google Calendar URL"
+                label-placement="stacked"
+                formControlName="googleCalendarUrl"
+                fill="outline"
+              ></ion-input>
+            </ion-col>
+          </ion-row>
+        </ion-col>
+        <ion-col>
+          <ion-row>
+            <ion-col>
                   <!-- <ion-label position="stacked">Description</ion-label> -->
                   <ion-textarea
                     label="Description"

--- a/src/app/modules/account/pages/registration/components/group-registration/group-registration.component.ts
+++ b/src/app/modules/account/pages/registration/components/group-registration/group-registration.component.ts
@@ -72,6 +72,7 @@ export class GroupRegistrationComponent implements OnChanges {
       }),
       groupDetails: this.fb.group({
         groupType: [],
+        googleCalendarUrl: [],
       }),
     });
   }
@@ -279,6 +280,10 @@ export class GroupRegistrationComponent implements OnChanges {
         addresses: this.account.contactInformation?.addresses || [
           this.createAddressFormGroup(),
         ],
+      },
+      groupDetails: {
+        groupType: this.account.groupDetails?.groupType,
+        googleCalendarUrl: this.account.groupDetails?.googleCalendarUrl,
       },
     });
   }

--- a/src/app/shared/pipes/safe-url.pipe.ts
+++ b/src/app/shared/pipes/safe-url.pipe.ts
@@ -1,0 +1,16 @@
+import {Pipe, PipeTransform} from '@angular/core';
+import {DomSanitizer, SafeResourceUrl} from '@angular/platform-browser';
+
+@Pipe({
+  name: 'safeUrl',
+})
+export class SafeUrlPipe implements PipeTransform {
+  constructor(private sanitizer: DomSanitizer) {}
+
+  transform(url: string | null | undefined): SafeResourceUrl | null {
+    if (!url) {
+      return null;
+    }
+    return this.sanitizer.bypassSecurityTrustResourceUrl(url);
+  }
+}


### PR DESCRIPTION
## Summary
- extend group model with `googleCalendarUrl`
- add SafeUrlPipe for embedding URLs
- show calendar iframe on group profiles
- allow admins to edit calendar URL in group forms

## Testing
- `npm run test` *(fails: Angular CLI requires newer Node.js)*

------
https://chatgpt.com/codex/tasks/task_e_687dc473e79c83269d5a489cc3755784