### PR TITLE
Use Firestore ID for new roles

### DIFF
--- a/src/app/modules/account/pages/role-management/role-management.page.spec.ts
+++ b/src/app/modules/account/pages/role-management/role-management.page.spec.ts
@@ -26,6 +26,7 @@ import {Store} from "@ngrx/store";
 import * as AccountActions from "../../../../state/actions/account.actions";
 import {RouterTestingModule} from "@angular/router/testing";
 import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
+import {AngularFirestore} from "@angular/fire/compat/firestore";
 
 describe("RoleManagementPage", () => {
   let component: RoleManagementPage;
@@ -35,7 +36,17 @@ describe("RoleManagementPage", () => {
     await TestBed.configureTestingModule({
       declarations: [RoleManagementPage],
       imports: [RouterTestingModule],
-      providers: [provideMockStore({})],
+      providers: [
+        provideMockStore({}),
+        {
+          provide: AngularFirestore,
+          useValue: {
+            createId: jasmine
+              .createSpy("createId")
+              .and.returnValue("generatedId"),
+          },
+        },
+      ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     }).compileComponents();
 
@@ -50,11 +61,19 @@ describe("RoleManagementPage", () => {
   it("should dispatch createGroupRole on addRole", () => {
     const store = TestBed.inject(Store);
     spyOn(store, "dispatch");
+    const afs = TestBed.inject(AngularFirestore);
+    (afs.createId as jasmine.Spy).and.returnValue("generatedId");
     component.newRole = {name: "Test"};
     component.addRole();
     expect(store.dispatch).toHaveBeenCalledWith(
-      jasmine.objectContaining({
-        type: AccountActions.createGroupRole.type,
+      AccountActions.createGroupRole({
+        groupId: component.groupId,
+        role: {
+          id: "generatedId",
+          name: "Test",
+          description: undefined,
+          parentRoleId: undefined,
+        },
       }),
     );
   });

--- a/src/app/modules/account/pages/role-management/role-management.page.ts
+++ b/src/app/modules/account/pages/role-management/role-management.page.ts
@@ -25,6 +25,7 @@ import {Store} from "@ngrx/store";
 import {Observable} from "rxjs";
 import {map} from "rxjs/operators";
 import {GroupRole} from "@shared/models/group-role.model";
+import {AngularFirestore} from "@angular/fire/compat/firestore";
 import * as AccountActions from "../../../../state/actions/account.actions";
 import {
   selectGroupRolesByGroupId,
@@ -47,6 +48,7 @@ export class RoleManagementPage implements OnInit {
   constructor(
     private route: ActivatedRoute,
     private store: Store,
+    private afs: AngularFirestore,
   ) {
     this.groupId = this.route.snapshot.paramMap.get("accountId") || "";
   }
@@ -63,7 +65,7 @@ export class RoleManagementPage implements OnInit {
   addRole() {
     if (!this.newRole.name) return;
     const role: GroupRole = {
-      id: Date.now().toString(),
+      id: this.afs.createId(),
       name: this.newRole.name!,
       description: this.newRole.description,
       parentRoleId: this.newRole.parentRoleId,


### PR DESCRIPTION
## Summary
- inject `AngularFirestore` into `RoleManagementPage`
- generate new role IDs via `AngularFirestore.createId`
- expect generated ID in role management tests

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_687f02dc3e7c832690c508c1d3f3997d