### PR TITLE
Add role hierarchy page

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ We look forward to your contributions and engaging discussions!
   - Real-time data to address issues
   - Collaboration features, such as event proposals, voting, and commenting
   - Landing page lead form to collect inquiries
+  - [Role hierarchy view](docs/role-hierarchy.md)
 
 - Utopian Think Tank
   - Collaborate with organizations and research

--- a/docs/role-hierarchy.md
+++ b/docs/role-hierarchy.md
@@ -1,0 +1,9 @@
+# Role Hierarchy Page
+
+The role hierarchy page visualizes custom roles defined for a group and which accounts hold each role. Navigate to:
+
+```
+/account/:accountId/role-hierarchy
+```
+
+Replace `:accountId` with the ID of the group. The page retrieves group roles and related accounts from the store and builds a tree using each role's `parentRoleId`. Under every role the related accounts assigned to that role are listed.

--- a/src/app/modules/account/account-routing.module.ts
+++ b/src/app/modules/account/account-routing.module.ts
@@ -29,6 +29,7 @@ import {UsersPage} from "./pages/users/users.page";
 import {ListPage} from "./relatedAccount/pages/list/list.page";
 import {ListingsListPage} from "./relatedListings/pages/listings-list/listings-list.page";
 import {RoleManagementPage} from "./pages/role-management/role-management.page";
+import {RoleHierarchyPage} from "./pages/role-hierarchy/role-hierarchy.page";
 
 const routes: Routes = [
   {
@@ -73,6 +74,11 @@ const routes: Routes = [
   {
     path: ":accountId/roles",
     component: RoleManagementPage,
+    canActivate: [AuthGuard],
+  },
+  {
+    path: ":accountId/role-hierarchy",
+    component: RoleHierarchyPage,
     canActivate: [AuthGuard],
   },
 ];

--- a/src/app/modules/account/account.module.ts
+++ b/src/app/modules/account/account.module.ts
@@ -56,6 +56,7 @@ import {ListPage} from "./relatedAccount/pages/list/list.page";
 import {RelatedListingsComponent} from "./pages/details/components/related-listings/related-listings.component";
 import {ListingsListPage} from "./relatedListings/pages/listings-list/listings-list.page";
 import {RoleManagementPage} from "./pages/role-management/role-management.page";
+import {RoleHierarchyPage} from "./pages/role-hierarchy/role-hierarchy.page";
 import {SafeUrlPipe} from "../../shared/pipes/safe-url.pipe";
 import {GroupCalendarComponent} from "./pages/details/components/group-calendar/group-calendar.component";
 
@@ -88,6 +89,7 @@ import {GroupCalendarComponent} from "./pages/details/components/group-calendar/
     ListPage,
     RelatedListingsComponent,
     RoleManagementPage,
+    RoleHierarchyPage,
     GroupCalendarComponent,
     SafeUrlPipe,
   ],

--- a/src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.html
+++ b/src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.html
@@ -1,0 +1,44 @@
+<!--
+Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+Copyright (C) 2023  ASCENDynamics NFP
+
+This file is part of Nonprofit Social Networking Platform.
+
+Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+-->
+<ion-header>
+  <app-header [title]="'Role Hierarchy'" [defaultHref]="'../'"></app-header>
+</ion-header>
+
+<ion-content>
+  <ng-container *ngIf="roleTree$ | async as tree">
+    <ng-container *ngTemplateOutlet="nodeList; context:{ nodes: tree }"></ng-container>
+  </ng-container>
+
+  <ng-template #nodeList let-nodes="nodes">
+    <ion-list>
+      <ng-container *ngFor="let node of nodes">
+        <ion-item lines="none">
+          <ion-label class="ion-text-wrap">
+            <h2>{{ node.role.name }}</h2>
+            <p *ngFor="let acc of node.relatedAccounts">{{ acc.name }}</p>
+          </ion-label>
+        </ion-item>
+        <div class="child-nodes" *ngIf="node.children.length > 0" style="padding-left: 16px;">
+          <ng-container *ngTemplateOutlet="nodeList; context:{ nodes: node.children }"></ng-container>
+        </div>
+      </ng-container>
+    </ion-list>
+  </ng-template>
+</ion-content>

--- a/src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.scss
+++ b/src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.scss
@@ -1,0 +1,24 @@
+/*
+Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+Copyright (C) 2023  ASCENDynamics NFP
+
+This file is part of Nonprofit Social Networking Platform.
+
+Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+*/
+.child-nodes {
+  border-left: 1px solid var(--ion-color-medium);
+  margin-left: 8px;
+  padding-left: 8px;
+}

--- a/src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.spec.ts
+++ b/src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.spec.ts
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ *******************************************************************************/
+// src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.spec.ts
+
+import {ComponentFixture, TestBed} from "@angular/core/testing";
+import {RoleHierarchyPage} from "./role-hierarchy.page";
+import {provideMockStore, MockStore} from "@ngrx/store/testing";
+import {Store} from "@ngrx/store";
+import * as AccountActions from "../../../../state/actions/account.actions";
+import {CUSTOM_ELEMENTS_SCHEMA} from "@angular/core";
+import {RouterTestingModule} from "@angular/router/testing";
+
+describe("RoleHierarchyPage", () => {
+  let component: RoleHierarchyPage;
+  let fixture: ComponentFixture<RoleHierarchyPage>;
+  let store: MockStore;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [RoleHierarchyPage],
+      imports: [RouterTestingModule],
+      providers: [provideMockStore({})],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    }).compileComponents();
+
+    store = TestBed.inject(MockStore);
+    fixture = TestBed.createComponent(RoleHierarchyPage);
+    component = fixture.componentInstance;
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("should dispatch load actions on ngOnInit", () => {
+    spyOn(store, "dispatch");
+    component.ngOnInit();
+    expect(store.dispatch).toHaveBeenCalledWith(
+      AccountActions.loadGroupRoles({groupId: component.accountId}),
+    );
+    expect(store.dispatch).toHaveBeenCalledWith(
+      AccountActions.loadRelatedAccounts({accountId: component.accountId}),
+    );
+  });
+});

--- a/src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.ts
+++ b/src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.ts
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ *******************************************************************************/
+// src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.ts
+
+import {Component, OnInit} from "@angular/core";
+import {ActivatedRoute} from "@angular/router";
+import {Store} from "@ngrx/store";
+import {combineLatest, Observable} from "rxjs";
+import {map} from "rxjs/operators";
+import {GroupRole} from "@shared/models/group-role.model";
+import {RelatedAccount} from "@shared/models/account.model";
+import {
+  selectGroupRolesByGroupId,
+  selectRelatedAccountsByAccountId,
+} from "../../../../state/selectors/account.selectors";
+import * as AccountActions from "../../../../state/actions/account.actions";
+
+interface RoleNode {
+  role: GroupRole;
+  children: RoleNode[];
+  relatedAccounts: RelatedAccount[];
+}
+
+@Component({
+  selector: "app-role-hierarchy",
+  templateUrl: "./role-hierarchy.page.html",
+  styleUrls: ["./role-hierarchy.page.scss"],
+})
+export class RoleHierarchyPage implements OnInit {
+  accountId!: string;
+  roleTree$!: Observable<RoleNode[]>;
+
+  constructor(
+    private route: ActivatedRoute,
+    private store: Store,
+  ) {
+    this.accountId = this.route.snapshot.paramMap.get("accountId") || "";
+  }
+
+  ngOnInit() {
+    const roles$ = this.store.select(selectGroupRolesByGroupId(this.accountId));
+    const relatedAccounts$ = this.store.select(
+      selectRelatedAccountsByAccountId(this.accountId),
+    );
+
+    this.store.dispatch(
+      AccountActions.loadGroupRoles({groupId: this.accountId}),
+    );
+    this.store.dispatch(
+      AccountActions.loadRelatedAccounts({accountId: this.accountId}),
+    );
+
+    this.roleTree$ = combineLatest([roles$, relatedAccounts$]).pipe(
+      map(([roles, accounts]) => this.buildTree(roles, accounts)),
+    );
+  }
+
+  private buildTree(
+    roles: GroupRole[],
+    accounts: RelatedAccount[],
+  ): RoleNode[] {
+    const mapNodes = new Map<string, RoleNode>();
+    roles.forEach((role) =>
+      mapNodes.set(role.id, {role, children: [], relatedAccounts: []}),
+    );
+    roles.forEach((role) => {
+      if (role.parentRoleId) {
+        const parent = mapNodes.get(role.parentRoleId);
+        parent?.children.push(mapNodes.get(role.id)!);
+      }
+    });
+    accounts.forEach((acc) => {
+      if (acc.roleId) {
+        mapNodes.get(acc.roleId)?.relatedAccounts.push(acc);
+      }
+    });
+    return roles
+      .filter((r) => !r.parentRoleId)
+      .map((r) => mapNodes.get(r.id)!) as RoleNode[];
+  }
+}


### PR DESCRIPTION
## Summary
- add role hierarchy docs
- link role hierarchy docs in README
- register `RoleHierarchyPage` in account module and routing
- implement `RoleHierarchyPage` component

## Testing
- `npm run test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_687f074b147c83269e737d7c7745d282