### PR TITLE
Add role hierarchy page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Ascend Co-op Platform is an open-source platform built using Ionic and Firebase, aimed at fostering collaboration and growth for worker-owned cooperatives, nonprofit organizations, and private organizations. It offers features like user profiles, group management, real-time data, and collaboration tools to address various challenges and facilitate communication between organizations.
 
 For a deeper look at the application layout and how the frontend communicates with Firebase, see [docs/architecture.md](docs/architecture.md).
+To learn about the new role hierarchy view, read [docs/role-hierarchy.md](docs/role-hierarchy.md).
 
 
 ## Development

--- a/docs/role-hierarchy.md
+++ b/docs/role-hierarchy.md
@@ -1,0 +1,7 @@
+# Role Hierarchy Page
+
+The role hierarchy page visualizes group roles together with the members who hold those roles.
+
+Navigate to `/account/<accountId>/role-hierarchy` to view a tree of roles for a group account. Roles are grouped by their `parentRoleId` so nested roles appear underneath their parent.
+
+For each role node the page lists related accounts whose `roleId` matches that role. The component retrieves data from NgRx state using the existing selectors `selectGroupRolesByGroupId` and `selectRelatedAccountsByAccountId`.

--- a/src/app/modules/account/account-routing.module.ts
+++ b/src/app/modules/account/account-routing.module.ts
@@ -29,6 +29,7 @@ import {UsersPage} from "./pages/users/users.page";
 import {ListPage} from "./relatedAccount/pages/list/list.page";
 import {ListingsListPage} from "./relatedListings/pages/listings-list/listings-list.page";
 import {RoleManagementPage} from "./pages/role-management/role-management.page";
+import {RoleHierarchyPage} from "./pages/role-hierarchy/role-hierarchy.page";
 
 const routes: Routes = [
   {
@@ -73,6 +74,11 @@ const routes: Routes = [
   {
     path: ":accountId/roles",
     component: RoleManagementPage,
+    canActivate: [AuthGuard],
+  },
+  {
+    path: ":accountId/role-hierarchy",
+    component: RoleHierarchyPage,
     canActivate: [AuthGuard],
   },
 ];

--- a/src/app/modules/account/account.module.ts
+++ b/src/app/modules/account/account.module.ts
@@ -56,6 +56,7 @@ import {ListPage} from "./relatedAccount/pages/list/list.page";
 import {RelatedListingsComponent} from "./pages/details/components/related-listings/related-listings.component";
 import {ListingsListPage} from "./relatedListings/pages/listings-list/listings-list.page";
 import {RoleManagementPage} from "./pages/role-management/role-management.page";
+import {RoleHierarchyPage} from "./pages/role-hierarchy/role-hierarchy.page";
 import {SafeUrlPipe} from "../../shared/pipes/safe-url.pipe";
 import {GroupCalendarComponent} from "./pages/details/components/group-calendar/group-calendar.component";
 
@@ -88,6 +89,7 @@ import {GroupCalendarComponent} from "./pages/details/components/group-calendar/
     ListPage,
     RelatedListingsComponent,
     RoleManagementPage,
+    RoleHierarchyPage,
     GroupCalendarComponent,
     SafeUrlPipe,
   ],

--- a/src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.html
+++ b/src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.html
@@ -1,0 +1,48 @@
+<!--
+Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+Copyright (C) 2023  ASCENDynamics NFP
+
+This file is part of Nonprofit Social Networking Platform.
+
+Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published
+by the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+-->
+<!-- src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.html -->
+
+<ion-header>
+  <app-header [title]="'Role Hierarchy'" [defaultHref]="'../'"></app-header>
+</ion-header>
+
+<ion-content>
+  <ng-container *ngIf="roleTree$ | async as tree">
+    <ul>
+      <ng-template #recursiveList let-nodes>
+        <li *ngFor="let node of nodes">
+          <strong>{{ node.role.name }}</strong>
+          <span *ngIf="node.role.description">- {{ node.role.description }}</span>
+          <ul>
+            <li *ngFor="let account of node.relatedAccounts">
+              {{ account.name || account.id }}
+            </li>
+          </ul>
+          <ul *ngIf="node.children.length">
+            <ng-container
+              *ngTemplateOutlet="recursiveList; context: { $implicit: node.children }"
+            ></ng-container>
+          </ul>
+        </li>
+      </ng-template>
+      <ng-container *ngTemplateOutlet="recursiveList; context: { $implicit: tree }"></ng-container>
+    </ul>
+  </ng-container>
+</ion-content>

--- a/src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.scss
+++ b/src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.scss
@@ -1,0 +1,9 @@
+/* role-hierarchy.page.scss */
+ul {
+  list-style-type: none;
+  padding-left: 1rem;
+}
+
+li {
+  margin-bottom: 0.5rem;
+}

--- a/src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.spec.ts
+++ b/src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.spec.ts
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ *******************************************************************************/
+// src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.spec.ts
+
+import {ComponentFixture, TestBed} from "@angular/core/testing";
+import {provideMockStore} from "@ngrx/store/testing";
+import {RouterTestingModule} from "@angular/router/testing";
+import {RoleHierarchyPage} from "./role-hierarchy.page";
+
+describe("RoleHierarchyPage", () => {
+  let component: RoleHierarchyPage;
+  let fixture: ComponentFixture<RoleHierarchyPage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [RoleHierarchyPage],
+      imports: [RouterTestingModule],
+      providers: [provideMockStore({})],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(RoleHierarchyPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.ts
+++ b/src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.ts
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ *******************************************************************************/
+// src/app/modules/account/pages/role-hierarchy/role-hierarchy.page.ts
+
+import {Component, OnInit} from "@angular/core";
+import {ActivatedRoute} from "@angular/router";
+import {Store} from "@ngrx/store";
+import {Observable, combineLatest} from "rxjs";
+import {map} from "rxjs/operators";
+import {GroupRole} from "@shared/models/group-role.model";
+import {RelatedAccount} from "@shared/models/account.model";
+import {
+  selectGroupRolesByGroupId,
+  selectRelatedAccountsByAccountId,
+} from "../../../../state/selectors/account.selectors";
+import * as AccountActions from "../../../../state/actions/account.actions";
+
+interface RoleNode {
+  role: GroupRole;
+  children: RoleNode[];
+  relatedAccounts: RelatedAccount[];
+}
+
+@Component({
+  selector: "app-role-hierarchy",
+  templateUrl: "./role-hierarchy.page.html",
+  styleUrls: ["./role-hierarchy.page.scss"],
+})
+export class RoleHierarchyPage implements OnInit {
+  accountId!: string;
+  roleTree$!: Observable<RoleNode[]>;
+
+  constructor(
+    private route: ActivatedRoute,
+    private store: Store,
+  ) {
+    this.accountId = this.route.snapshot.paramMap.get("accountId") || "";
+  }
+
+  ngOnInit() {
+    const roles$ = this.store.select(selectGroupRolesByGroupId(this.accountId));
+    const related$ = this.store.select(
+      selectRelatedAccountsByAccountId(this.accountId),
+    );
+
+    this.roleTree$ = combineLatest([roles$, related$]).pipe(
+      map(([roles, related]) => this.buildRoleTree(roles, related)),
+    );
+
+    this.store.dispatch(
+      AccountActions.loadGroupRoles({groupId: this.accountId}),
+    );
+    this.store.dispatch(
+      AccountActions.loadRelatedAccounts({accountId: this.accountId}),
+    );
+  }
+
+  private buildRoleTree(
+    roles: GroupRole[],
+    relatedAccounts: RelatedAccount[],
+  ): RoleNode[] {
+    const accountsByRole: {[id: string]: RelatedAccount[]} = {};
+    for (const account of relatedAccounts) {
+      if (!account.roleId) continue;
+      if (!accountsByRole[account.roleId]) {
+        accountsByRole[account.roleId] = [];
+      }
+      accountsByRole[account.roleId].push(account);
+    }
+
+    const nodeMap: Map<string, RoleNode> = new Map();
+    roles.forEach((role) =>
+      nodeMap.set(role.id, {
+        role,
+        children: [],
+        relatedAccounts: accountsByRole[role.id] || [],
+      }),
+    );
+
+    const roots: RoleNode[] = [];
+    nodeMap.forEach((node) => {
+      if (node.role.parentRoleId && nodeMap.has(node.role.parentRoleId)) {
+        nodeMap.get(node.role.parentRoleId)!.children.push(node);
+      } else {
+        roots.push(node);
+      }
+    });
+
+    return roots;
+  }
+}


### PR DESCRIPTION
## Summary
- show role hierarchies for group accounts
- wire up `:accountId/role-hierarchy` route
- document the feature

## Testing
- `npm test` *(fails: Chrome missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f0aba682883269c2edf5cbbe586f8