### PR TITLE
Add basic time tracking module

### DIFF
--- a/shared/models/project.model.ts
+++ b/shared/models/project.model.ts
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ ********************************************************************************/
+// shared/models/project.model.ts
+
+import {BaseDocument} from "./base-document";
+
+export interface Project extends BaseDocument {
+  name: string;
+  color?: string;
+  clientId?: string;
+  archived?: boolean;
+}

--- a/shared/models/time-entry.model.ts
+++ b/shared/models/time-entry.model.ts
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ ********************************************************************************/
+// shared/models/time-entry.model.ts
+
+import {Timestamp} from "firebase/firestore";
+import {BaseDocument} from "./base-document";
+
+export interface TimeEntry extends BaseDocument {
+  projectId: string;
+  userId: string;
+  date: Timestamp;
+  hours: number;
+  notes?: string;
+}

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -49,6 +49,13 @@ export const routes: Routes = [
       import("./modules/listing/listing.module").then((m) => m.ListingModule),
   },
   {
+    path: "time-tracking",
+    loadChildren: () =>
+      import("./modules/time-tracking/time-tracking.module").then(
+        (m) => m.TimeTrackingModule,
+      ),
+  },
+  {
     path: "info", // Used to organize routes in "/info" folder.
     loadChildren: () =>
       import("./modules/info/info.module").then((m) => m.InfoModule),

--- a/src/app/core/services/time-tracking.service.ts
+++ b/src/app/core/services/time-tracking.service.ts
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ ********************************************************************************/
+// src/app/core/services/time-tracking.service.ts
+
+import {Injectable} from "@angular/core";
+import {AngularFirestore} from "@angular/fire/compat/firestore";
+import {Observable, of, from} from "rxjs";
+import {catchError, map} from "rxjs/operators";
+import {FirestoreService} from "./firestore.service";
+import {Project} from "@shared/models/project.model";
+import {TimeEntry} from "@shared/models/time-entry.model";
+
+@Injectable({
+  providedIn: "root",
+})
+export class TimeTrackingService {
+  constructor(
+    private afs: AngularFirestore,
+    private firestore: FirestoreService,
+  ) {}
+
+  getProjects(): Observable<Project[]> {
+    return this.afs
+      .collection<Project>("projects")
+      .snapshotChanges()
+      .pipe(
+        map((actions) =>
+          actions.map((a) => {
+            const data = a.payload.doc.data() as Project;
+            const id = a.payload.doc.id;
+            return {...data, id};
+          }),
+        ),
+        catchError((error) => {
+          console.error("Error loading projects:", error);
+          return of([]);
+        }),
+      );
+  }
+
+  getUserEntries(userId: string): Observable<TimeEntry[]> {
+    return this.afs
+      .collection<TimeEntry>("timeEntries", (ref) =>
+        ref.where("userId", "==", userId),
+      )
+      .snapshotChanges()
+      .pipe(
+        map((actions) =>
+          actions.map((a) => {
+            const data = a.payload.doc.data() as TimeEntry;
+            const id = a.payload.doc.id;
+            return {...data, id};
+          }),
+        ),
+        catchError((error) => {
+          console.error("Error loading time entries:", error);
+          return of([]);
+        }),
+      );
+  }
+
+  addTimeEntry(entry: TimeEntry): Promise<string> {
+    return this.firestore.addDocument("timeEntries", entry);
+  }
+
+  updateTimeEntry(entry: TimeEntry): Promise<void> {
+    return this.firestore.updateDocument("timeEntries", entry.id, entry);
+  }
+}

--- a/src/app/modules/account/pages/registration/components/user-registration/user-registration.component.spec.ts
+++ b/src/app/modules/account/pages/registration/components/user-registration/user-registration.component.spec.ts
@@ -29,6 +29,7 @@ describe("UserRegistrationComponent", () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
+      declarations: [UserRegistrationComponent],
       imports: [IonicModule.forRoot()],
       providers: [provideMockStore()],
       schemas: [NO_ERRORS_SCHEMA],

--- a/src/app/modules/listing/relatedAccount/pages/applicants/applicants.page.spec.ts
+++ b/src/app/modules/listing/relatedAccount/pages/applicants/applicants.page.spec.ts
@@ -163,6 +163,7 @@ describe("ApplicantsPage", () => {
       listings: listingsState,
       auth: {user: mockAuthUser, error: null, loading: false},
       accounts: accountsState,
+      timeTracking: {projects: [], loading: false, error: null},
     };
   }
 

--- a/src/app/modules/time-tracking/components/week-view/week-view.component.html
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.html
@@ -1,0 +1,14 @@
+<table class="week-grid">
+  <thead>
+    <tr>
+      <th>Project</th>
+      <th *ngFor="let day of days">{{ day | date:'EEE MM/dd' }}</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Example Project</td>
+      <td *ngFor="let day of days"></td>
+    </tr>
+  </tbody>
+</table>

--- a/src/app/modules/time-tracking/components/week-view/week-view.component.scss
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.scss
@@ -1,0 +1,10 @@
+.week-grid {
+  width: 100%;
+  border-collapse: collapse;
+}
+.week-grid th,
+.week-grid td {
+  border: 1px solid #ccc;
+  text-align: center;
+  padding: 8px;
+}

--- a/src/app/modules/time-tracking/components/week-view/week-view.component.spec.ts
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.spec.ts
@@ -1,0 +1,21 @@
+import {ComponentFixture, TestBed} from "@angular/core/testing";
+import {WeekViewComponent} from "./week-view.component";
+
+describe("WeekViewComponent", () => {
+  let component: WeekViewComponent;
+  let fixture: ComponentFixture<WeekViewComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [WeekViewComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WeekViewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/time-tracking/components/week-view/week-view.component.ts
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.ts
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ ********************************************************************************/
+// src/app/modules/time-tracking/components/week-view/week-view.component.ts
+
+import {Component, Input, OnInit} from "@angular/core";
+
+@Component({
+  selector: "app-week-view",
+  templateUrl: "./week-view.component.html",
+  styleUrls: ["./week-view.component.scss"],
+})
+export class WeekViewComponent implements OnInit {
+  @Input() weekStart: Date = new Date();
+  days: Date[] = [];
+
+  ngOnInit() {
+    const start = new Date(this.weekStart);
+    start.setHours(0, 0, 0, 0);
+    for (let i = 0; i < 7; i++) {
+      const day = new Date(start);
+      day.setDate(start.getDate() + i);
+      this.days.push(day);
+    }
+  }
+}

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.html
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.html
@@ -1,0 +1,9 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Timesheet</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <app-week-view></app-week-view>
+</ion-content>

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.scss
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.scss
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.spec.ts
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.spec.ts
@@ -1,6 +1,7 @@
 import {ComponentFixture, TestBed} from "@angular/core/testing";
 import {IonicModule} from "@ionic/angular";
 import {TimesheetPage} from "./timesheet.page";
+import {provideMockStore} from "@ngrx/store/testing";
 
 describe("TimesheetPage", () => {
   let component: TimesheetPage;
@@ -10,6 +11,7 @@ describe("TimesheetPage", () => {
     await TestBed.configureTestingModule({
       declarations: [TimesheetPage],
       imports: [IonicModule.forRoot()],
+      providers: [provideMockStore()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TimesheetPage);

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.spec.ts
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.spec.ts
@@ -1,0 +1,23 @@
+import {ComponentFixture, TestBed} from "@angular/core/testing";
+import {IonicModule} from "@ionic/angular";
+import {TimesheetPage} from "./timesheet.page";
+
+describe("TimesheetPage", () => {
+  let component: TimesheetPage;
+  let fixture: ComponentFixture<TimesheetPage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TimesheetPage],
+      imports: [IonicModule.forRoot()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TimesheetPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.ts
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.ts
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ ********************************************************************************/
+// src/app/modules/time-tracking/pages/timesheet/timesheet.page.ts
+
+import {Component, OnInit} from "@angular/core";
+import {Store} from "@ngrx/store";
+import {Observable} from "rxjs";
+import {Project} from "@shared/models/project.model";
+import * as TimeTrackingActions from "../../../../state/actions/time-tracking.actions";
+
+@Component({
+  selector: "app-timesheet",
+  templateUrl: "./timesheet.page.html",
+  styleUrls: ["./timesheet.page.scss"],
+})
+export class TimesheetPage implements OnInit {
+  projects$!: Observable<Project[]>;
+
+  constructor(private store: Store<{timeTracking: {projects: Project[]}}>) {}
+
+  ngOnInit() {
+    this.projects$ = this.store.select((state) => state.timeTracking.projects);
+    this.store.dispatch(TimeTrackingActions.loadProjects());
+  }
+}

--- a/src/app/modules/time-tracking/time-tracking-routing.module.ts
+++ b/src/app/modules/time-tracking/time-tracking-routing.module.ts
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ ********************************************************************************/
+// src/app/modules/time-tracking/time-tracking-routing.module.ts
+
+import {NgModule} from "@angular/core";
+import {RouterModule, Routes} from "@angular/router";
+import {TimesheetPage} from "./pages/timesheet/timesheet.page";
+import {AuthGuard} from "../../core/guards/auth.guard";
+
+const routes: Routes = [
+  {
+    path: "",
+    component: TimesheetPage,
+    canActivate: [AuthGuard],
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class TimeTrackingRoutingModule {}

--- a/src/app/modules/time-tracking/time-tracking.module.ts
+++ b/src/app/modules/time-tracking/time-tracking.module.ts
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ ********************************************************************************/
+// src/app/modules/time-tracking/time-tracking.module.ts
+
+import {NgModule} from "@angular/core";
+import {CommonModule} from "@angular/common";
+import {FormsModule} from "@angular/forms";
+import {IonicModule} from "@ionic/angular";
+import {RouterModule} from "@angular/router";
+import {StoreModule} from "@ngrx/store";
+import {EffectsModule} from "@ngrx/effects";
+import {TimeTrackingRoutingModule} from "./time-tracking-routing.module";
+import {TimesheetPage} from "./pages/timesheet/timesheet.page";
+import {WeekViewComponent} from "./components/week-view/week-view.component";
+import {timeTrackingReducer} from "../../state/reducers/time-tracking.reducer";
+import {TimeTrackingEffects} from "../../state/effects/time-tracking.effects";
+import {SharedModule} from "../../shared/shared.module";
+
+@NgModule({
+  declarations: [TimesheetPage, WeekViewComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule,
+    RouterModule,
+    SharedModule,
+    TimeTrackingRoutingModule,
+    StoreModule.forFeature("timeTracking", timeTrackingReducer),
+    EffectsModule.forFeature([TimeTrackingEffects]),
+  ],
+})
+export class TimeTrackingModule {}

--- a/src/app/state/actions/time-tracking.actions.ts
+++ b/src/app/state/actions/time-tracking.actions.ts
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ ********************************************************************************/
+// src/app/state/actions/time-tracking.actions.ts
+
+import {createAction, props} from "@ngrx/store";
+import {Project} from "@shared/models/project.model";
+import {TimeEntry} from "@shared/models/time-entry.model";
+
+export const loadProjects = createAction("[Time Tracking] Load Projects");
+
+export const loadProjectsSuccess = createAction(
+  "[Time Tracking] Load Projects Success",
+  props<{projects: Project[]}>(),
+);
+
+export const loadProjectsFailure = createAction(
+  "[Time Tracking] Load Projects Failure",
+  props<{error: any}>(),
+);
+
+export const saveTimeEntry = createAction(
+  "[Time Tracking] Save Time Entry",
+  props<{entry: TimeEntry}>(),
+);
+
+export const saveTimeEntrySuccess = createAction(
+  "[Time Tracking] Save Time Entry Success",
+  props<{entry: TimeEntry}>(),
+);
+
+export const saveTimeEntryFailure = createAction(
+  "[Time Tracking] Save Time Entry Failure",
+  props<{error: any}>(),
+);

--- a/src/app/state/app.state.ts
+++ b/src/app/state/app.state.ts
@@ -22,9 +22,11 @@
 import {AccountState} from "./reducers/account.reducer";
 import {AuthState} from "./reducers/auth.reducer";
 import {ListingsState} from "./reducers/listings.reducer";
+import {TimeTrackingState} from "./reducers/time-tracking.reducer";
 
 export interface AppState {
   accounts: AccountState;
   auth: AuthState;
   listings: ListingsState;
+  timeTracking: TimeTrackingState;
 }

--- a/src/app/state/effects/time-tracking.effects.ts
+++ b/src/app/state/effects/time-tracking.effects.ts
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ ********************************************************************************/
+// src/app/state/effects/time-tracking.effects.ts
+
+import {Injectable} from "@angular/core";
+import {Actions, createEffect, ofType} from "@ngrx/effects";
+import {mergeMap, map, catchError} from "rxjs/operators";
+import {of, from} from "rxjs";
+import {TimeTrackingService} from "../../core/services/time-tracking.service";
+import * as TimeTrackingActions from "../actions/time-tracking.actions";
+import {TimeEntry} from "@shared/models/time-entry.model";
+
+@Injectable()
+export class TimeTrackingEffects {
+  constructor(
+    private actions$: Actions,
+    private service: TimeTrackingService,
+  ) {}
+
+  loadProjects$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(TimeTrackingActions.loadProjects),
+      mergeMap(() =>
+        this.service.getProjects().pipe(
+          map((projects) =>
+            TimeTrackingActions.loadProjectsSuccess({projects}),
+          ),
+          catchError((error) =>
+            of(TimeTrackingActions.loadProjectsFailure({error})),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  saveEntry$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(TimeTrackingActions.saveTimeEntry),
+      mergeMap(({entry}) =>
+        from(this.service.addTimeEntry(entry as TimeEntry)).pipe(
+          map((id) =>
+            TimeTrackingActions.saveTimeEntrySuccess({
+              entry: {...entry, id},
+            }),
+          ),
+          catchError((error) =>
+            of(TimeTrackingActions.saveTimeEntryFailure({error})),
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/src/app/state/reducers/index.ts
+++ b/src/app/state/reducers/index.ts
@@ -23,11 +23,12 @@ import {ActionReducerMap} from "@ngrx/store";
 import {authReducer} from "./auth.reducer";
 import {accountReducer} from "./account.reducer";
 import {listingsReducer} from "./listings.reducer";
+import {timeTrackingReducer} from "./time-tracking.reducer";
 import {AppState} from "../app.state";
 
 export const reducers: ActionReducerMap<AppState> = {
   auth: authReducer,
   accounts: accountReducer,
   listings: listingsReducer,
-  // Other reducers...
+  timeTracking: timeTrackingReducer,
 };

--- a/src/app/state/reducers/time-tracking.reducer.ts
+++ b/src/app/state/reducers/time-tracking.reducer.ts
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ ********************************************************************************/
+// src/app/state/reducers/time-tracking.reducer.ts
+
+import {createReducer, on} from "@ngrx/store";
+import * as TimeTrackingActions from "../actions/time-tracking.actions";
+import {Project} from "@shared/models/project.model";
+
+export interface TimeTrackingState {
+  projects: Project[];
+  loading: boolean;
+  error: any;
+}
+
+export const initialState: TimeTrackingState = {
+  projects: [],
+  loading: false,
+  error: null,
+};
+
+export const timeTrackingReducer = createReducer(
+  initialState,
+  on(TimeTrackingActions.loadProjects, (state) => ({
+    ...state,
+    loading: true,
+  })),
+  on(TimeTrackingActions.loadProjectsSuccess, (state, {projects}) => ({
+    ...state,
+    projects,
+    loading: false,
+    error: null,
+  })),
+  on(TimeTrackingActions.loadProjectsFailure, (state, {error}) => ({
+    ...state,
+    loading: false,
+    error,
+  })),
+  on(TimeTrackingActions.saveTimeEntry, (state) => ({
+    ...state,
+    loading: true,
+  })),
+  on(TimeTrackingActions.saveTimeEntrySuccess, (state) => ({
+    ...state,
+    loading: false,
+    error: null,
+  })),
+  on(TimeTrackingActions.saveTimeEntryFailure, (state, {error}) => ({
+    ...state,
+    loading: false,
+    error,
+  })),
+);


### PR DESCRIPTION
## Summary
- create `time-tracking` module with routing and Timesheet page
- implement week view component
- add `Project` and `TimeEntry` models
- provide `TimeTrackingService`
- integrate NgRx actions, reducer and effects
- patch tests for new AppState structure

## Testing
- `npm install`
- `npm run test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_688054e6889483269b9d4e564f30ba1c