### PR TITLE
Add time entry approval trigger

### DIFF
--- a/functions/src/database/timeEntries/triggers/onUpdate/index.ts
+++ b/functions/src/database/timeEntries/triggers/onUpdate/index.ts
@@ -1,0 +1,86 @@
+/**
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************************/
+
+import {
+  onDocumentUpdated,
+  Change,
+  FirestoreEvent,
+} from "firebase-functions/v2/firestore";
+import {admin} from "../../../../utils/firebase";
+import * as logger from "firebase-functions/logger";
+import {QueryDocumentSnapshot} from "firebase-admin/firestore";
+
+/**
+ * Cloud Function triggered when a time entry document is updated.
+ * It updates the user's totalHours on status approval or reversal.
+ */
+export const onUpdateTimeEntry = onDocumentUpdated(
+  {
+    document: "accounts/{accountId}/timeEntries/{entryId}",
+    region: "us-central1",
+  },
+  handleTimeEntryUpdate,
+);
+
+async function handleTimeEntryUpdate(
+  event: FirestoreEvent<
+    Change<QueryDocumentSnapshot> | undefined,
+    {accountId: string; entryId: string}
+  >,
+) {
+  if (!event.data?.after || !event.data?.before) {
+    logger.error("Missing before or after data in update event");
+    return;
+  }
+
+  const after = event.data.after.data();
+  const before = event.data.before.data();
+
+  const userId = after.userId || before.userId;
+  const hours = after.hours || 0;
+
+  if (!userId) {
+    logger.error("Time entry missing userId");
+    return;
+  }
+
+  try {
+    if (before.status !== "approved" && after.status === "approved") {
+      // Increment hours when entry is approved
+      await admin
+        .firestore()
+        .doc(`accounts/${userId}`)
+        .update({
+          totalHours: admin.firestore.FieldValue.increment(hours),
+        });
+    } else if (before.status === "approved" && after.status !== "approved") {
+      // Decrement hours if approval is reversed
+      await admin
+        .firestore()
+        .doc(`accounts/${userId}`)
+        .update({
+          totalHours: admin.firestore.FieldValue.increment(-hours),
+        });
+    }
+  } catch (error) {
+    logger.error("Error updating total hours:", error);
+  }
+}
+

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -56,6 +56,8 @@ export {onDeleteAccountsRelatedListing} from "./database/accounts/relatedListing
 export {onCreateListing} from "./database/listings/triggers/onCreate";
 export {onDeleteListing} from "./database/listings/triggers/onDelete";
 export {onUpdateListing} from "./database/listings/triggers/onUpdate";
+// Time entry triggers
+export {onUpdateTimeEntry} from "./database/timeEntries/triggers/onUpdate";
 
 // Listings related accounts triggers
 export {onCreateListingsRelatedAccount} from "./database/listings/relatedAccounts/triggers/onCreate";

--- a/functions/test/timeentry.spec.ts
+++ b/functions/test/timeentry.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ *********************************************************************************/
+// functions/test/timeentry.spec.ts
+
+import {expect} from "chai";
+import * as sinon from "sinon";
+const proxyquire = require("proxyquire");
+
+describe("onUpdateTimeEntry", () => {
+  function setup() {
+    const updateStub = sinon.stub().resolves();
+    const docStub = sinon.stub().returns({update: updateStub});
+    const incrementStub = sinon.stub().returnsArg(0);
+
+    const firestoreFn: any = sinon.stub().returns({doc: docStub});
+    firestoreFn.FieldValue = {increment: incrementStub};
+
+    const adminStub = {firestore: firestoreFn};
+
+    let handler: any;
+    proxyquire("../src/database/timeEntries/triggers/onUpdate", {
+      "../../../../utils/firebase": {admin: adminStub},
+      "firebase-functions/logger": {info: sinon.stub(), error: sinon.stub()},
+      "firebase-functions/v2/firestore": {
+        onDocumentUpdated: (_cfg: any, fn: any) => {
+          handler = fn;
+          return fn;
+        },
+      },
+    });
+
+    return {handler, updateStub, incrementStub, docStub};
+  }
+
+  it("increments hours when approved", async () => {
+    const {handler, updateStub, incrementStub, docStub} = setup();
+    const before = {data: () => ({status: "pending", userId: "u", hours: 2})};
+    const after = {data: () => ({status: "approved", userId: "u", hours: 2})};
+    await handler({data: {before, after}, params: {accountId: "a", entryId: "e"}});
+    expect(docStub.calledWith("accounts/u")).to.be.true;
+    expect(incrementStub.calledWith(2)).to.be.true;
+    expect(updateStub.calledOnce).to.be.true;
+  });
+
+  it("decrements hours when approval is removed", async () => {
+    const {handler, updateStub, incrementStub, docStub} = setup();
+    const before = {data: () => ({status: "approved", userId: "u", hours: 3})};
+    const after = {data: () => ({status: "pending", userId: "u", hours: 3})};
+    await handler({data: {before, after}, params: {accountId: "a", entryId: "e"}});
+    expect(docStub.calledWith("accounts/u")).to.be.true;
+    expect(incrementStub.calledWith(-3)).to.be.true;
+    expect(updateStub.calledOnce).to.be.true;
+  });
+});
+


### PR DESCRIPTION
## Summary
- add time entry update trigger that adjusts account hours
- expose new trigger from index
- test approved and reversed updates
- update time entry trigger path

## Testing
- `npm --prefix functions test`


------
https://chatgpt.com/codex/tasks/task_e_6880580a3d908326a08f2e3680e185bf