### PR TITLE
Add time entry security rules

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -17,6 +17,24 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "timeEntries",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "orgId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "userId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "weekStart",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -104,6 +104,31 @@ service cloud.firestore {
     match /accounts/{accountId}/relatedListings/{listingId} {
       allow create, read, write, delete: if request.auth.uid != null;  // Only authenticated users
     }
+
+    // Time entries within group accounts
+    match /accounts/{accountId}/timeEntries/{entryId} {
+      function isGroupAccount() {
+        return get(/databases/$(database)/documents/accounts/$(accountId)).data.type == 'group';
+      }
+
+      function isGroupMember() {
+        return request.auth != null &&
+          exists(/databases/$(database)/documents/accounts/$(accountId)/relatedAccounts/$(request.auth.uid)) &&
+          get(/databases/$(database)/documents/accounts/$(accountId)/relatedAccounts/$(request.auth.uid)).data.status == 'accepted';
+      }
+
+      function isGroupAdmin() {
+        return request.auth != null &&
+          exists(/databases/$(database)/documents/accounts/$(accountId)/relatedAccounts/$(request.auth.uid)) &&
+          get(/databases/$(database)/documents/accounts/$(accountId)/relatedAccounts/$(request.auth.uid)).data.access == 'admin';
+      }
+
+      allow read: if isGroupAccount() && isGroupMember();
+      allow create: if isGroupAccount() && request.auth.uid == request.resource.data.userId && isGroupMember();
+      allow update: if isGroupAccount() && request.auth.uid == request.resource.data.userId && isGroupMember() &&
+        (request.resource.data.status == 'approved' ? isGroupAdmin() : true);
+      allow delete: if false;
+    }
     
     // Rules for AppFeedback
     match /feedback/{accountId} {


### PR DESCRIPTION
## Summary
- add security rules for organizations time entries
- index new time entry fields for efficient queries
- adjust time entry rules to account-based groups

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688057e2cfd48326861e0127817c366d