### PR TITLE
Add totalHours field to Account model

### DIFF
--- a/functions/src/auth/user/triggers/onCreate/index.ts
+++ b/functions/src/auth/user/triggers/onCreate/index.ts
@@ -67,6 +67,7 @@ async function saveAccountToFirestore(
     },
     email: user.email,
     privacy: "public",
+    totalHours: 0,
     legalAgreements: {
       termsOfService: {
         accepted: true,

--- a/shared/models/account.model.ts
+++ b/shared/models/account.model.ts
@@ -235,6 +235,10 @@ export interface Account extends BaseDocument, Group, User {
   webLinks: WebLink[]; // Links to social media, personal websites, etc.
   lastLoginAt: Timestamp;
   email: string;
+  /**
+   * Total volunteer hours logged for this account
+   */
+  totalHours?: number;
   settings?: Settings; // User-specific settings
 }
 

--- a/src/app/state/effects/account.effects.ts
+++ b/src/app/state/effects/account.effects.ts
@@ -490,21 +490,23 @@ export class AccountEffects {
           take(1),
           filter((fresh) => !fresh),
           switchMap(() =>
-            this.firestoreService.getDocument<Account>('accounts', groupId).pipe(
-              map((account) =>
-                AccountActions.loadGroupRolesSuccess({
-                  groupId,
-                  roles: account?.roles || [],
-                }),
-              ),
-              catchError((error) =>
-                of(
-                  AccountActions.loadGroupRolesFailure({
-                    error: error.message,
+            this.firestoreService
+              .getDocument<Account>("accounts", groupId)
+              .pipe(
+                map((account) =>
+                  AccountActions.loadGroupRolesSuccess({
+                    groupId,
+                    roles: account?.roles || [],
                   }),
                 ),
+                catchError((error) =>
+                  of(
+                    AccountActions.loadGroupRolesFailure({
+                      error: error.message,
+                    }),
+                  ),
+                ),
               ),
-            ),
           ),
         ),
       ),
@@ -566,11 +568,11 @@ export class AccountEffects {
     modifier: (roles: GroupRole[]) => GroupRole[],
   ): Promise<GroupRole[]> {
     const account = await firstValueFrom(
-      this.firestoreService.getDocument<Account>('accounts', groupId),
+      this.firestoreService.getDocument<Account>("accounts", groupId),
     );
     const currentRoles = account?.roles || [];
     const updatedRoles = modifier(currentRoles);
-    await this.firestoreService.updateDocument('accounts', groupId, {
+    await this.firestoreService.updateDocument("accounts", groupId, {
       roles: updatedRoles,
     });
     return updatedRoles;
@@ -579,6 +581,7 @@ export class AccountEffects {
   private async createAccountWithResume(account: Account): Promise<Account> {
     const newAccount: any = {
       ...account,
+      totalHours: account.totalHours ?? 0,
       createdAt: serverTimestamp(),
       lastModifiedAt: serverTimestamp(),
     };


### PR DESCRIPTION
## Summary
- extend `Account` model with `totalHours`
- default `totalHours` to `0` on account creation in the UI effects
- ensure new user profiles start with 0 hours in cloud functions

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_688060f652808326929322ebd2fa2c0b