### PR TITLE
Add timeEntries index on orgId and status

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -35,6 +35,24 @@
           "order": "ASCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "timeEntries",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "orgId",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "weekStart",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary
- expand Cloud Firestore indexes with `orgId` and `status`

## Testing
- `npm test` *(fails: Chrome browser not found)*
- `npx firebase-tools deploy --only firestore:indexes` *(fails: authentication error)*

------
https://chatgpt.com/codex/tasks/task_e_688061629bdc8326945d47b48815b6cb