### PR TITLE
Update time entry storage

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -18,6 +18,16 @@ service cloud.firestore {
       allow create, read, write, delete: if request.auth.uid != null; // Only authenticated users
     }
 
+    // Projects collection rules
+    match /projects {
+      allow list: if request.auth != null;
+    }
+
+    match /projects/{projectId} {
+      allow read: if request.auth != null;
+      allow create, update, delete: if request.auth != null;
+    }
+
     match /accounts {
       allow list: if isPublicUser() || isPublicGroup();
 

--- a/shared/models/time-entry.model.ts
+++ b/shared/models/time-entry.model.ts
@@ -23,6 +23,8 @@ import {Timestamp} from "firebase/firestore";
 import {BaseDocument} from "./base-document";
 
 export interface TimeEntry extends BaseDocument {
+  /** The account/group this entry belongs to */
+  accountId: string;
   projectId: string;
   userId: string;
   date: Timestamp;

--- a/src/app/core/services/time-tracking.service.ts
+++ b/src/app/core/services/time-tracking.service.ts
@@ -55,9 +55,9 @@ export class TimeTrackingService {
       );
   }
 
-  getUserEntries(userId: string): Observable<TimeEntry[]> {
+  getUserEntries(accountId: string, userId: string): Observable<TimeEntry[]> {
     return this.afs
-      .collection<TimeEntry>("timeEntries", (ref) =>
+      .collection<TimeEntry>(`accounts/${accountId}/timeEntries`, (ref) =>
         ref.where("userId", "==", userId),
       )
       .snapshotChanges()
@@ -77,10 +77,17 @@ export class TimeTrackingService {
   }
 
   addTimeEntry(entry: TimeEntry): Promise<string> {
-    return this.firestore.addDocument("timeEntries", entry);
+    return this.firestore.addDocument(
+      `accounts/${entry.accountId}/timeEntries`,
+      entry,
+    );
   }
 
   updateTimeEntry(entry: TimeEntry): Promise<void> {
-    return this.firestore.updateDocument("timeEntries", entry.id, entry);
+    return this.firestore.updateDocument(
+      `accounts/${entry.accountId}/timeEntries`,
+      entry.id,
+      entry,
+    );
   }
 }

--- a/src/app/state/effects/time-tracking.effects.ts
+++ b/src/app/state/effects/time-tracking.effects.ts
@@ -25,7 +25,6 @@ import {mergeMap, map, catchError} from "rxjs/operators";
 import {of, from} from "rxjs";
 import {TimeTrackingService} from "../../core/services/time-tracking.service";
 import * as TimeTrackingActions from "../actions/time-tracking.actions";
-import {TimeEntry} from "@shared/models/time-entry.model";
 
 @Injectable()
 export class TimeTrackingEffects {
@@ -54,7 +53,7 @@ export class TimeTrackingEffects {
     this.actions$.pipe(
       ofType(TimeTrackingActions.saveTimeEntry),
       mergeMap(({entry}) =>
-        from(this.service.addTimeEntry(entry as TimeEntry)).pipe(
+        from(this.service.addTimeEntry(entry)).pipe(
           map((id) =>
             TimeTrackingActions.saveTimeEntrySuccess({
               entry: {...entry, id},


### PR DESCRIPTION
## Summary
- scope time entries under each account
- track `accountId` on `TimeEntry` objects
- update actions and effects for time entry save
- allow access to `projects` collection in Firestore rules

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6880613a7f448326a3d0f31b9e00748b