### PR TITLE
Add userId input for week view

### DIFF
--- a/src/app/modules/time-tracking/components/week-view/week-view.component.spec.ts
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.spec.ts
@@ -19,6 +19,8 @@ describe("WeekViewComponent", () => {
     fixture = TestBed.createComponent(WeekViewComponent);
     component = fixture.componentInstance;
 
+    component.userId = "test";
+
     component.projects = [
       {id: "p1", name: "Project 1"} as any,
       {id: "p2", name: "Project 2"} as any,
@@ -56,6 +58,21 @@ describe("WeekViewComponent", () => {
     expect(store.dispatch).toHaveBeenCalledWith(
       jasmine.objectContaining({
         type: TimeTrackingActions.saveTimeEntry.type,
+      }),
+    );
+  });
+
+  it("should include userId when creating new entry", () => {
+    const nextDay = new Date(component.weekStart);
+    nextDay.setDate(nextDay.getDate() + 1);
+    component.onHoursChange(component.projects[0], nextDay, {
+      target: {value: "3"},
+    } as any);
+
+    expect(store.dispatch).toHaveBeenCalledWith(
+      jasmine.objectContaining({
+        type: TimeTrackingActions.saveTimeEntry.type,
+        entry: jasmine.objectContaining({userId: "test"}),
       }),
     );
   });

--- a/src/app/modules/time-tracking/components/week-view/week-view.component.ts
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.ts
@@ -36,6 +36,7 @@ export class WeekViewComponent implements OnInit {
   @Input() projects: Project[] = [];
   @Input() entries: TimeEntry[] = [];
   @Input() accountId: string = "";
+  @Input() userId: string = "";
 
   days: Date[] = [];
 
@@ -63,7 +64,7 @@ export class WeekViewComponent implements OnInit {
   onHoursChange(project: Project, day: Date, event: Event) {
     const target = event.target as HTMLInputElement;
     if (!target) return;
-    
+
     const hours = Number(target.value);
     if (isNaN(hours)) {
       return;
@@ -73,7 +74,7 @@ export class WeekViewComponent implements OnInit {
       id: existing ? existing.id : "",
       accountId: this.accountId,
       projectId: project.id,
-      userId: existing ? existing.userId : "", // You'll need to get current user ID
+      userId: existing ? existing.userId : this.userId,
       date: existing ? existing.date : Timestamp.fromDate(day),
       hours,
       notes: existing?.notes,

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.html
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.html
@@ -5,5 +5,5 @@
 </ion-header>
 
 <ion-content>
-  <app-week-view [accountId]="accountId"></app-week-view>
+  <app-week-view [accountId]="accountId" [userId]="userId"></app-week-view>
 </ion-content>

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.spec.ts
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.spec.ts
@@ -1,11 +1,13 @@
 import {ComponentFixture, TestBed} from "@angular/core/testing";
 import {IonicModule} from "@ionic/angular";
 import {TimesheetPage} from "./timesheet.page";
-import {provideMockStore} from "@ngrx/store/testing";
+import {provideMockStore, MockStore} from "@ngrx/store/testing";
+import {selectAuthUser} from "../../../../state/selectors/auth.selectors";
 
 describe("TimesheetPage", () => {
   let component: TimesheetPage;
   let fixture: ComponentFixture<TimesheetPage>;
+  let store: MockStore;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -14,6 +16,9 @@ describe("TimesheetPage", () => {
       providers: [provideMockStore()],
     }).compileComponents();
 
+    store = TestBed.inject(MockStore);
+    store.overrideSelector(selectAuthUser, {uid: "test"} as any);
+
     fixture = TestBed.createComponent(TimesheetPage);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -21,5 +26,9 @@ describe("TimesheetPage", () => {
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  it("should set userId from auth selector", () => {
+    expect(component.userId).toBe("test");
   });
 });

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.ts
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.ts
@@ -22,8 +22,10 @@
 import {Component, OnInit} from "@angular/core";
 import {Store} from "@ngrx/store";
 import {Observable} from "rxjs";
+import {first} from "rxjs/operators";
 import {Project} from "@shared/models/project.model";
 import * as TimeTrackingActions from "../../../../state/actions/time-tracking.actions";
+import {selectAuthUser} from "../../../../state/selectors/auth.selectors";
 
 @Component({
   selector: "app-timesheet",
@@ -33,11 +35,19 @@ import * as TimeTrackingActions from "../../../../state/actions/time-tracking.ac
 export class TimesheetPage implements OnInit {
   projects$!: Observable<Project[]>;
   accountId: string = ""; // You'll need to get this from route params or auth service
+  userId: string = "";
 
   constructor(private store: Store<{timeTracking: {projects: Project[]}}>) {}
 
   ngOnInit() {
     this.projects$ = this.store.select((state) => state.timeTracking.projects);
     this.store.dispatch(TimeTrackingActions.loadProjects());
+
+    this.store
+      .select(selectAuthUser)
+      .pipe(first())
+      .subscribe((user) => {
+        this.userId = user?.uid ?? "";
+      });
   }
 }


### PR DESCRIPTION
## Summary
- pass `userId` from `TimesheetPage` to `WeekViewComponent`
- include new `userId` input for `WeekViewComponent`
- set `userId` when creating new time entries
- update unit tests for the new behavior

## Testing
- `npm test` *(fails: Chrome browser not available)*

------
https://chatgpt.com/codex/tasks/task_e_68807d2ab78483268eb520d1ac8d575b