### PR TITLE
Restrict time entry editing after approval

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -135,8 +135,15 @@ service cloud.firestore {
 
       allow read: if isGroupAccount() && isGroupMember();
       allow create: if isGroupAccount() && request.auth.uid == request.resource.data.userId && isGroupMember();
-      allow update: if isGroupAccount() && request.auth.uid == request.resource.data.userId && isGroupMember() &&
-        (request.resource.data.status == 'approved' ? isGroupAdmin() : true);
+      allow update: if isGroupAccount() && isGroupMember() &&
+        (
+          isGroupAdmin() ||
+          (
+            request.auth.uid == resource.data.userId &&
+            request.auth.uid == request.resource.data.userId &&
+            resource.data.status != 'approved'
+          )
+        );
       allow delete: if false;
     }
     


### PR DESCRIPTION
## Summary
- update group time entry rule so only admins can modify approved entries

## Testing
- `npm run test` *(fails: Chrome not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68807d4078c8832697ec15c4d59dc483