### PR TITLE
Add project selector to week view

### DIFF
--- a/src/app/modules/time-tracking/components/week-view/week-view.component.html
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.html
@@ -1,3 +1,15 @@
+<button (click)="toggleProjectDropdown()">Add Project</button>
+<select *ngIf="dropdownOpen" (change)="addProjectById($event.target.value)">
+  <option value="">Select...</option>
+  <option
+    *ngFor="let proj of availableProjects"
+    [value]="proj.id"
+    [disabled]="isSelected(proj.id)"
+  >
+    {{ proj.name }}
+  </option>
+</select>
+
 <table class="week-grid">
   <thead>
     <tr>

--- a/src/app/modules/time-tracking/components/week-view/week-view.component.spec.ts
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.spec.ts
@@ -23,6 +23,10 @@ describe("WeekViewComponent", () => {
       {id: "p1", name: "Project 1"} as any,
       {id: "p2", name: "Project 2"} as any,
     ];
+    component.availableProjects = [
+      ...component.projects,
+      {id: "p3", name: "Project 3"} as any,
+    ];
 
     const today = new Date();
     component.weekStart = today;
@@ -58,5 +62,25 @@ describe("WeekViewComponent", () => {
         type: TimeTrackingActions.saveTimeEntry.type,
       }),
     );
+  });
+
+  it("should add a row when a project is added", () => {
+    component.addProjectById("p3");
+    fixture.detectChanges();
+    const rows = fixture.nativeElement.querySelectorAll("tbody tr");
+    expect(rows.length).toBe(3);
+  });
+
+  it("should not dispatch when hours empty for new entry", () => {
+    component.addProjectById("p3");
+    fixture.detectChanges();
+    store.dispatch.calls.reset();
+    const inputs = fixture.nativeElement.querySelectorAll(
+      "tbody tr:last-child input",
+    );
+    const input = inputs[0] as HTMLInputElement;
+    input.value = "";
+    input.dispatchEvent(new Event("change"));
+    expect(store.dispatch).not.toHaveBeenCalled();
   });
 });

--- a/src/app/modules/time-tracking/components/week-view/week-view.component.ts
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.ts
@@ -34,10 +34,12 @@ import {TimeEntry} from "@shared/models/time-entry.model";
 export class WeekViewComponent implements OnInit {
   @Input() weekStart: Date = new Date();
   @Input() projects: Project[] = [];
+  @Input() availableProjects: Project[] = [];
   @Input() entries: TimeEntry[] = [];
   @Input() accountId: string = "";
 
   days: Date[] = [];
+  dropdownOpen = false;
 
   constructor(private store: Store) {}
 
@@ -63,12 +65,15 @@ export class WeekViewComponent implements OnInit {
   onHoursChange(project: Project, day: Date, event: Event) {
     const target = event.target as HTMLInputElement;
     if (!target) return;
-    
+
     const hours = Number(target.value);
     if (isNaN(hours)) {
       return;
     }
     const existing = this.getEntry(project.id, day);
+    if (!existing && (!target.value || hours === 0)) {
+      return;
+    }
     const entry: TimeEntry = {
       id: existing ? existing.id : "",
       accountId: this.accountId,
@@ -79,5 +84,21 @@ export class WeekViewComponent implements OnInit {
       notes: existing?.notes,
     };
     this.store.dispatch(TimeTrackingActions.saveTimeEntry({entry}));
+  }
+
+  toggleProjectDropdown() {
+    this.dropdownOpen = !this.dropdownOpen;
+  }
+
+  isSelected(id: string): boolean {
+    return this.projects.some((p) => p.id === id);
+  }
+
+  addProjectById(id: string) {
+    const project = this.availableProjects.find((p) => p.id === id);
+    if (project && !this.isSelected(id)) {
+      this.projects.push(project);
+    }
+    this.dropdownOpen = false;
   }
 }

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.html
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.html
@@ -5,5 +5,8 @@
 </ion-header>
 
 <ion-content>
-  <app-week-view [accountId]="accountId"></app-week-view>
+  <app-week-view
+    [accountId]="accountId"
+    [availableProjects]="projects$ | async"
+  ></app-week-view>
 </ion-content>


### PR DESCRIPTION
## Summary
- add dropdown to choose projects in week view
- append project rows when selected
- skip creating entries when no hours entered
- expose available projects on timesheet page
- test adding new project rows

## Testing
- `npm test` *(fails: Chrome binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_688080076e108326a2403a92991af811