### PR TITLE
Enhance time entry model and save logic

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -22,36 +22,16 @@
       "collectionGroup": "timeEntries",
       "queryScope": "COLLECTION",
       "fields": [
-        {
-          "fieldPath": "orgId",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "userId",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "weekStart",
-          "order": "ASCENDING"
-        }
+        {"fieldPath": "accountId", "order": "ASCENDING"},
+        {"fieldPath": "userId", "order": "ASCENDING"}
       ]
     },
     {
       "collectionGroup": "timeEntries",
       "queryScope": "COLLECTION",
       "fields": [
-        {
-          "fieldPath": "orgId",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "status",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "weekStart",
-          "order": "ASCENDING"
-        }
+        {"fieldPath": "accountId", "order": "ASCENDING"},
+        {"fieldPath": "status", "order": "ASCENDING"}
       ]
     }
   ],

--- a/shared/models/time-entry.model.ts
+++ b/shared/models/time-entry.model.ts
@@ -29,5 +29,11 @@ export interface TimeEntry extends BaseDocument {
   userId: string;
   date: Timestamp;
   hours: number;
+  /**
+   * Approval status of the time entry. Newly created entries should be
+   * saved with 'pending' status and may later transition to 'approved'
+   * or 'rejected'.
+   */
+  status?: "pending" | "approved" | "rejected";
   notes?: string;
 }

--- a/src/app/modules/time-tracking/components/week-view/week-view.component.spec.ts
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.spec.ts
@@ -39,6 +39,7 @@ describe("WeekViewComponent", () => {
         userId: "u1",
         date: Timestamp.fromDate(today),
         hours: 1,
+        status: "pending",
       } as any,
     ];
 
@@ -65,7 +66,6 @@ describe("WeekViewComponent", () => {
       }),
     );
   });
-
 
   it("should include userId when creating new entry", () => {
     const nextDay = new Date(component.weekStart);

--- a/src/app/modules/time-tracking/components/week-view/week-view.component.ts
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.ts
@@ -82,6 +82,7 @@ export class WeekViewComponent implements OnInit {
       userId: existing ? existing.userId : this.userId,
       date: existing ? existing.date : Timestamp.fromDate(day),
       hours,
+      status: existing ? existing.status : "pending",
       notes: existing?.notes,
     };
     this.store.dispatch(TimeTrackingActions.saveTimeEntry({entry}));

--- a/src/app/state/effects/time-tracking.effects.ts
+++ b/src/app/state/effects/time-tracking.effects.ts
@@ -52,18 +52,19 @@ export class TimeTrackingEffects {
   saveEntry$ = createEffect(() =>
     this.actions$.pipe(
       ofType(TimeTrackingActions.saveTimeEntry),
-      mergeMap(({entry}) =>
-        from(this.service.addTimeEntry(entry)).pipe(
+      mergeMap(({entry}) => {
+        const save$ = entry.id
+          ? from(this.service.updateTimeEntry(entry)).pipe(map(() => entry.id))
+          : from(this.service.addTimeEntry(entry));
+        return save$.pipe(
           map((id) =>
-            TimeTrackingActions.saveTimeEntrySuccess({
-              entry: {...entry, id},
-            }),
+            TimeTrackingActions.saveTimeEntrySuccess({entry: {...entry, id}}),
           ),
           catchError((error) =>
             of(TimeTrackingActions.saveTimeEntryFailure({error})),
           ),
-        ),
-      ),
+        );
+      }),
     ),
   );
 }


### PR DESCRIPTION
## Summary
- add `status` property to TimeEntry model
- update WeekView to include status when saving
- adjust effects to update existing time entries
- correct Firestore indexes for accountId
- update spec to include status

## Testing
- `npm --prefix functions test`
- `CHROME_BIN=$(which chromium-browser) npm test` *(fails: Chrome not available)*

------
https://chatgpt.com/codex/tasks/task_e_68805f42e05483269b57025d9499b840