### PR TITLE
Update time entry create rule

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -150,7 +150,7 @@ service cloud.firestore {
       }
 
       allow read: if isGroupAccount() && isGroupMember();
-      allow create: if isGroupAccount() && request.auth.uid == request.resource.data.userId && isGroupMember();
+      allow create: if isGroupAccount() && request.auth.uid == request.resource.data.userId && isGroupMember() && (isGroupAdmin() || request.resource.data.status == 'pending');
       allow update: if isGroupAccount() && isGroupMember() &&
         (
           isGroupAdmin() ||

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -13,6 +13,7 @@
         "nodemailer": "^6.10.0"
       },
       "devDependencies": {
+        "@firebase/rules-unit-testing": "^3.0.2",
         "@types/chai": "^4.3.5",
         "@types/mocha": "^10.0.2",
         "@types/node": "^20.13.0",
@@ -1221,6 +1222,72 @@
       "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.3.2.tgz",
       "integrity": "sha512-0BC4+Ud7y2aPTyhXJTMTFfrGGLqdYXrUB9sJVAB8NiqJswDTc4/2qrE/yfUbnQJhbSi6ZaTTBKyG3n1nplssaA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/rules-unit-testing": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@firebase/rules-unit-testing/-/rules-unit-testing-3.0.4.tgz",
+      "integrity": "sha512-FxDc5rnTtt266PTs3dOkf4ZDq+P223TrFWXka/yG6gSFy3Es/iKwWh3bX9pROobHgbbrAd7she9+687yOC2z+A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node-fetch": "2.6.4",
+        "node-fetch": "2.6.7"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      },
+      "peerDependencies": {
+        "firebase": "^10.0.0"
+      }
+    },
+    "node_modules/@firebase/rules-unit-testing/node_modules/@types/node-fetch": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
+      "integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
+    },
+    "node_modules/@firebase/rules-unit-testing/node_modules/form-data": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
+      "integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@firebase/rules-unit-testing/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@firebase/storage": {
       "version": "0.13.2",
@@ -10417,8 +10484,8 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/ts-deepmerge": {
       "version": "2.0.7",
@@ -10884,8 +10951,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "optional": true
+      "devOptional": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
@@ -10914,8 +10981,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/functions/package.json
+++ b/functions/package.json
@@ -37,6 +37,7 @@
     "eslint-config-google": "^0.14.0",
     "eslint-plugin-import": "^2.25.4",
     "firebase-functions-test": "^3.1.0",
+    "@firebase/rules-unit-testing": "^3.0.2",
     "mocha": "^10.0.0",
     "proxyquire": "^2.1.3",
     "sinon": "^17.0.1",

--- a/functions/test/firestore.rules.spec.ts
+++ b/functions/test/firestore.rules.spec.ts
@@ -1,0 +1,81 @@
+import {
+  initializeTestEnvironment,
+  RulesTestEnvironment,
+  assertFails,
+  assertSucceeds,
+} from "@firebase/rules-unit-testing";
+import {setDoc, doc} from "firebase/firestore";
+import * as fs from "fs";
+import * as path from "path";
+
+describe("timeEntries create rules", () => {
+  let testEnv: RulesTestEnvironment;
+
+  before(async () => {
+    testEnv = await initializeTestEnvironment({
+      projectId: "rules-test",
+      firestore: {
+        rules: fs.readFileSync(
+          path.join(__dirname, "..", "..", "firestore.rules"),
+          "utf8",
+        ),
+      },
+    });
+  });
+
+  after(async () => {
+    await testEnv.cleanup();
+  });
+
+  beforeEach(async () => {
+    await testEnv.clearFirestore();
+    await testEnv.withSecurityRulesDisabled(async (context) => {
+      const db = context.firestore();
+      // Create group account and related user documents
+      await setDoc(doc(db, "accounts/group1"), {type: "group"});
+      await setDoc(doc(db, "accounts/group1/relatedAccounts/user1"), {
+        status: "accepted",
+        access: "user",
+        type: "user",
+      });
+      await setDoc(doc(db, "accounts/group1/relatedAccounts/admin1"), {
+        status: "accepted",
+        access: "admin",
+        type: "user",
+      });
+    });
+  });
+
+  it("allows non-admin create when status pending", async () => {
+    const ctx = testEnv.authenticatedContext("user1");
+    const db = ctx.firestore();
+    await assertSucceeds(
+      setDoc(doc(db, "accounts/group1/timeEntries/entry1"), {
+        userId: "user1",
+        status: "pending",
+      }),
+    );
+  });
+
+  it("denies non-admin create with non pending status", async () => {
+    const ctx = testEnv.authenticatedContext("user1");
+    const db = ctx.firestore();
+    await assertFails(
+      setDoc(doc(db, "accounts/group1/timeEntries/entry1"), {
+        userId: "user1",
+        status: "approved",
+      }),
+    );
+  });
+
+  it("allows admin create with any status", async () => {
+    const ctx = testEnv.authenticatedContext("admin1");
+    const db = ctx.firestore();
+    await assertSucceeds(
+      setDoc(doc(db, "accounts/group1/timeEntries/entry1"), {
+        userId: "admin1",
+        status: "approved",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- restrict time entry creation status
- add Firestore rules tests verifying pending status rule
- include rules-unit-testing as dev dependency for functions

## Testing
- `CHROME_BIN=chromium-browser npm run test` *(fails: Chrome not installed)*
- `npm --prefix functions test` *(fails: Firestore emulator host and port not specified)*

------
https://chatgpt.com/codex/tasks/task_e_68819293e4d08326a8d1acb9195d4688