### PR TITLE
Fix duplicate week-view

### DIFF
--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.html
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.html
@@ -5,9 +5,9 @@
 </ion-header>
 
 <ion-content>
-  <app-week-view [accountId]="accountId" [userId]="userId"></app-week-view>
   <app-week-view
     [accountId]="accountId"
-    [availableProjects]="(projects$ | async) || []"
+    [availableProjects]="projects$ | async"
+    [userId]="userId"
   ></app-week-view>
 </ion-content>


### PR DESCRIPTION
## Summary
- remove extra `<app-week-view>` on Timesheet page
- pass projects and user ID to the component

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_688192ab653483268a08e03ee306e40b