### PR TITLE
Implement time entry loading

### DIFF
--- a/src/app/modules/listing/relatedAccount/pages/applicants/applicants.page.spec.ts
+++ b/src/app/modules/listing/relatedAccount/pages/applicants/applicants.page.spec.ts
@@ -163,7 +163,7 @@ describe("ApplicantsPage", () => {
       listings: listingsState,
       auth: {user: mockAuthUser, error: null, loading: false},
       accounts: accountsState,
-      timeTracking: {projects: [], loading: false, error: null},
+      timeTracking: {projects: [], entries: [], loading: false, error: null},
     };
   }
 

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.html
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.html
@@ -5,9 +5,10 @@
 </ion-header>
 
 <ion-content>
-  <app-week-view [accountId]="accountId" [userId]="userId"></app-week-view>
   <app-week-view
     [accountId]="accountId"
+    [userId]="userId"
+    [entries]="(entries$ | async) || []"
     [availableProjects]="(projects$ | async) || []"
   ></app-week-view>
 </ion-content>

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.ts
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.ts
@@ -26,6 +26,8 @@ import {first} from "rxjs/operators";
 import {Project} from "@shared/models/project.model";
 import * as TimeTrackingActions from "../../../../state/actions/time-tracking.actions";
 import {selectAuthUser} from "../../../../state/selectors/auth.selectors";
+import {TimeEntry} from "@shared/models/time-entry.model";
+import {AppState} from "../../../../state/app.state";
 
 @Component({
   selector: "app-timesheet",
@@ -34,19 +36,29 @@ import {selectAuthUser} from "../../../../state/selectors/auth.selectors";
 })
 export class TimesheetPage implements OnInit {
   projects$!: Observable<Project[]>;
+  entries$!: Observable<TimeEntry[]>;
   accountId: string = ""; // You'll need to get this from route params or auth service
   userId: string = "";
 
-  constructor(private store: Store<{timeTracking: {projects: Project[]}}>) {}
+  constructor(private store: Store<AppState>) {}
 
   ngOnInit() {
     this.projects$ = this.store.select((state) => state.timeTracking.projects);
+    this.entries$ = this.store.select((state) => state.timeTracking.entries);
 
     this.store
       .select(selectAuthUser)
       .pipe(first())
       .subscribe((user) => {
         this.userId = user?.uid ?? "";
+        if (this.userId) {
+          this.store.dispatch(
+            TimeTrackingActions.loadTimeEntries({
+              accountId: this.accountId,
+              userId: this.userId,
+            }),
+          );
+        }
       });
 
     this.store.dispatch(

--- a/src/app/state/actions/time-tracking.actions.ts
+++ b/src/app/state/actions/time-tracking.actions.ts
@@ -52,3 +52,18 @@ export const saveTimeEntryFailure = createAction(
   "[Time Tracking] Save Time Entry Failure",
   props<{error: any}>(),
 );
+
+export const loadTimeEntries = createAction(
+  "[Time Tracking] Load Time Entries",
+  props<{accountId: string; userId: string}>(),
+);
+
+export const loadTimeEntriesSuccess = createAction(
+  "[Time Tracking] Load Time Entries Success",
+  props<{entries: TimeEntry[]}>(),
+);
+
+export const loadTimeEntriesFailure = createAction(
+  "[Time Tracking] Load Time Entries Failure",
+  props<{error: any}>(),
+);

--- a/src/app/state/effects/time-tracking.effects.ts
+++ b/src/app/state/effects/time-tracking.effects.ts
@@ -67,4 +67,20 @@ export class TimeTrackingEffects {
       }),
     ),
   );
+
+  loadEntries$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(TimeTrackingActions.loadTimeEntries),
+      mergeMap(({accountId, userId}) =>
+        this.service.getUserEntries(accountId, userId).pipe(
+          map((entries) =>
+            TimeTrackingActions.loadTimeEntriesSuccess({entries}),
+          ),
+          catchError((error) =>
+            of(TimeTrackingActions.loadTimeEntriesFailure({error})),
+          ),
+        ),
+      ),
+    ),
+  );
 }

--- a/src/app/state/reducers/time-tracking.reducer.ts
+++ b/src/app/state/reducers/time-tracking.reducer.ts
@@ -22,15 +22,18 @@
 import {createReducer, on} from "@ngrx/store";
 import * as TimeTrackingActions from "../actions/time-tracking.actions";
 import {Project} from "@shared/models/project.model";
+import {TimeEntry} from "@shared/models/time-entry.model";
 
 export interface TimeTrackingState {
   projects: Project[];
+  entries: TimeEntry[];
   loading: boolean;
   error: any;
 }
 
 export const initialState: TimeTrackingState = {
   projects: [],
+  entries: [],
   loading: false,
   error: null,
 };
@@ -62,6 +65,21 @@ export const timeTrackingReducer = createReducer(
     error: null,
   })),
   on(TimeTrackingActions.saveTimeEntryFailure, (state, {error}) => ({
+    ...state,
+    loading: false,
+    error,
+  })),
+  on(TimeTrackingActions.loadTimeEntries, (state) => ({
+    ...state,
+    loading: true,
+  })),
+  on(TimeTrackingActions.loadTimeEntriesSuccess, (state, {entries}) => ({
+    ...state,
+    entries,
+    loading: false,
+    error: null,
+  })),
+  on(TimeTrackingActions.loadTimeEntriesFailure, (state, {error}) => ({
     ...state,
     loading: false,
     error,


### PR DESCRIPTION
## Summary
- add loadTimeEntries actions
- fetch user entries via effect
- store entries in TimeTrackingState
- show entries in week view
- update applicants tests for new state shape

## Testing
- `npm test` *(fails: Chrome not found)*

------
https://chatgpt.com/codex/tasks/task_e_688192c14c548326981b1560246fd9f6