### PR TITLE
Implement time entry loading per account

### DIFF
--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.html
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.html
@@ -8,6 +8,7 @@
   <app-week-view
     [accountId]="accountId"
     [userId]="userId"
+    [projects]="(projects$ | async) || []"
     [entries]="(entries$ | async) || []"
     [availableProjects]="(projects$ | async) || []"
   ></app-week-view>

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.spec.ts
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.spec.ts
@@ -2,7 +2,12 @@ import {ComponentFixture, TestBed} from "@angular/core/testing";
 import {IonicModule} from "@ionic/angular";
 import {TimesheetPage} from "./timesheet.page";
 import {provideMockStore, MockStore} from "@ngrx/store/testing";
+import {ActivatedRoute} from "@angular/router";
 import {selectAuthUser} from "../../../../state/selectors/auth.selectors";
+import {
+  selectEntries,
+  selectProjects,
+} from "../../../../state/selectors/time-tracking.selectors";
 
 describe("TimesheetPage", () => {
   let component: TimesheetPage;
@@ -13,11 +18,19 @@ describe("TimesheetPage", () => {
     await TestBed.configureTestingModule({
       declarations: [TimesheetPage],
       imports: [IonicModule.forRoot()],
-      providers: [provideMockStore()],
+      providers: [
+        provideMockStore(),
+        {
+          provide: ActivatedRoute,
+          useValue: {snapshot: {paramMap: {get: () => "acc1"}}},
+        },
+      ],
     }).compileComponents();
 
     store = TestBed.inject(MockStore);
     store.overrideSelector(selectAuthUser, {uid: "test"} as any);
+    store.overrideSelector(selectProjects, []);
+    store.overrideSelector(selectEntries, []);
 
     fixture = TestBed.createComponent(TimesheetPage);
     component = fixture.componentInstance;
@@ -30,5 +43,16 @@ describe("TimesheetPage", () => {
 
   it("should set userId from auth selector", () => {
     expect(component.userId).toBe("test");
+  });
+
+  it("should read accountId from route params", () => {
+    expect(component.accountId).toBe("acc1");
+  });
+
+  it("should expose entries observable", (done) => {
+    component.entries$.subscribe((e) => {
+      expect(e).toEqual([]);
+      done();
+    });
   });
 });

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.ts
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.ts
@@ -21,11 +21,16 @@
 
 import {Component, OnInit} from "@angular/core";
 import {Store} from "@ngrx/store";
+import {ActivatedRoute} from "@angular/router";
 import {Observable} from "rxjs";
 import {first} from "rxjs/operators";
 import {Project} from "@shared/models/project.model";
 import * as TimeTrackingActions from "../../../../state/actions/time-tracking.actions";
 import {selectAuthUser} from "../../../../state/selectors/auth.selectors";
+import {
+  selectEntries,
+  selectProjects,
+} from "../../../../state/selectors/time-tracking.selectors";
 import {TimeEntry} from "@shared/models/time-entry.model";
 import {AppState} from "../../../../state/app.state";
 
@@ -37,14 +42,19 @@ import {AppState} from "../../../../state/app.state";
 export class TimesheetPage implements OnInit {
   projects$!: Observable<Project[]>;
   entries$!: Observable<TimeEntry[]>;
-  accountId: string = ""; // You'll need to get this from route params or auth service
+  accountId: string = "";
   userId: string = "";
 
-  constructor(private store: Store<AppState>) {}
+  constructor(
+    private store: Store<AppState>,
+    private route: ActivatedRoute,
+  ) {}
 
   ngOnInit() {
-    this.projects$ = this.store.select((state) => state.timeTracking.projects);
-    this.entries$ = this.store.select((state) => state.timeTracking.entries);
+    this.accountId = this.route.snapshot.paramMap.get("accountId") ?? "";
+
+    this.projects$ = this.store.select(selectProjects);
+    this.entries$ = this.store.select(selectEntries);
 
     this.store
       .select(selectAuthUser)

--- a/src/app/state/selectors/time-tracking.selectors.ts
+++ b/src/app/state/selectors/time-tracking.selectors.ts
@@ -1,0 +1,25 @@
+import {createFeatureSelector, createSelector} from "@ngrx/store";
+import {TimeTrackingState} from "../reducers/time-tracking.reducer";
+
+export const selectTimeTrackingState =
+  createFeatureSelector<TimeTrackingState>("timeTracking");
+
+export const selectProjects = createSelector(
+  selectTimeTrackingState,
+  (state) => state.projects,
+);
+
+export const selectEntries = createSelector(
+  selectTimeTrackingState,
+  (state) => state.entries,
+);
+
+export const selectTimeTrackingLoading = createSelector(
+  selectTimeTrackingState,
+  (state) => state.loading,
+);
+
+export const selectTimeTrackingError = createSelector(
+  selectTimeTrackingState,
+  (state) => state.error,
+);


### PR DESCRIPTION
## Summary
- pull accountId from `ActivatedRoute`
- dispatch `loadTimeEntries` for that account
- create `time-tracking` selectors
- wire projects and entries into WeekView
- test Timesheet routing and selectors

## Testing
- `npm test` *(fails: Chrome not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68819a0a5ab08326988f7621270b1baa