### PR TITLE
Nest projects under accounts

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -33,6 +33,13 @@
         {"fieldPath": "accountId", "order": "ASCENDING"},
         {"fieldPath": "status", "order": "ASCENDING"}
       ]
+    },
+    {
+      "collectionGroup": "projects",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {"fieldPath": "accountId", "order": "ASCENDING"}
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -33,15 +33,13 @@ service cloud.firestore {
       );
     }
 
-    // Projects collection rules
-    match /projects {
+    // Project subcollections within accounts
+    match /accounts/{accountId}/projects {
       allow list: if request.auth != null;
     }
-
-    match /projects/{projectId} {
+    match /accounts/{accountId}/projects/{projectId} {
       allow read: if request.auth != null;
-      allow create: if isAccountAdmin(request.resource.data.accountId);
-      allow update, delete: if isAccountAdmin(resource.data.accountId);
+      allow create, update, delete: if isAccountAdmin(accountId);
     }
 
     match /accounts {

--- a/src/app/core/services/time-tracking.service.spec.ts
+++ b/src/app/core/services/time-tracking.service.spec.ts
@@ -62,11 +62,7 @@ describe("TimeTrackingService", () => {
         },
       },
     ];
-    const whereSpy = jasmine.createSpy("where").and.returnValue({} as any);
-    (afsSpy.collection as any).and.callFake((name: string, fn?: any) => {
-      if (fn) {
-        fn({where: whereSpy});
-      }
+    (afsSpy.collection as any).and.callFake((name: string) => {
       return {
         snapshotChanges: () => of(snapshotActions as any),
       } as any;
@@ -77,10 +73,8 @@ describe("TimeTrackingService", () => {
       done();
     });
     expect(afsSpy.collection).toHaveBeenCalledWith(
-      "projects" as any,
-      jasmine.any(Function),
+      `accounts/${accountId}/projects` as any,
     );
-    expect(whereSpy).toHaveBeenCalledWith("accountId", "==", accountId);
   });
 
   it("should retrieve user time entries", (done) => {

--- a/src/app/core/services/time-tracking.service.ts
+++ b/src/app/core/services/time-tracking.service.ts
@@ -38,9 +38,7 @@ export class TimeTrackingService {
 
   getProjects(accountId: string): Observable<Project[]> {
     return this.afs
-      .collection<Project>("projects", (ref) =>
-        ref.where("accountId", "==", accountId),
-      )
+      .collection<Project>(`accounts/${accountId}/projects`)
       .snapshotChanges()
       .pipe(
         map((actions) =>


### PR DESCRIPTION
## Summary
- organize projects as subcollection under account documents
- update rules for account-based projects
- revise unit tests to query new collection path
- include indexes for projects

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68819b6f8b948326a8c6ac24716cd112