### PR TITLE
Add week navigation controls to timesheet

### DIFF
--- a/src/app/modules/time-tracking/components/week-view/week-view.component.spec.ts
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.spec.ts
@@ -3,6 +3,7 @@ import {WeekViewComponent} from "./week-view.component";
 import {Store} from "@ngrx/store";
 import {Timestamp} from "firebase/firestore";
 import * as TimeTrackingActions from "../../../../state/actions/time-tracking.actions";
+import {SimpleChange} from "@angular/core";
 
 describe("WeekViewComponent", () => {
   let component: WeekViewComponent;
@@ -102,5 +103,22 @@ describe("WeekViewComponent", () => {
     input.value = "";
     input.dispatchEvent(new Event("change"));
     expect(store.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("should update header dates when weekStart changes", () => {
+    const initialHeader: string = fixture.nativeElement.querySelectorAll(
+      "thead th",
+    )[1].textContent.trim();
+    const nextWeek = new Date(component.weekStart);
+    nextWeek.setDate(nextWeek.getDate() + 7);
+    component.weekStart = nextWeek;
+    component.ngOnChanges({
+      weekStart: new SimpleChange(null, nextWeek, false),
+    });
+    fixture.detectChanges();
+    const newHeader: string = fixture.nativeElement.querySelectorAll(
+      "thead th",
+    )[1].textContent.trim();
+    expect(newHeader).not.toBe(initialHeader);
   });
 });

--- a/src/app/modules/time-tracking/components/week-view/week-view.component.ts
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.ts
@@ -19,7 +19,7 @@
  ********************************************************************************/
 // src/app/modules/time-tracking/components/week-view/week-view.component.ts
 
-import {Component, Input, OnInit} from "@angular/core";
+import {Component, Input, OnInit, OnChanges, SimpleChanges} from "@angular/core";
 import {Store} from "@ngrx/store";
 import {Timestamp} from "firebase/firestore";
 import * as TimeTrackingActions from "../../../../state/actions/time-tracking.actions";
@@ -31,7 +31,7 @@ import {TimeEntry} from "@shared/models/time-entry.model";
   templateUrl: "./week-view.component.html",
   styleUrls: ["./week-view.component.scss"],
 })
-export class WeekViewComponent implements OnInit {
+export class WeekViewComponent implements OnInit, OnChanges {
   @Input() weekStart: Date = new Date();
   @Input() projects: Project[] = [];
   @Input() availableProjects: Project[] = [];
@@ -45,6 +45,17 @@ export class WeekViewComponent implements OnInit {
   constructor(private store: Store) {}
 
   ngOnInit() {
+    this.calculateDays();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes["weekStart"]) {
+      this.calculateDays();
+    }
+  }
+
+  private calculateDays() {
+    this.days = [];
     const start = new Date(this.weekStart);
     start.setHours(0, 0, 0, 0);
     for (let i = 0; i < 7; i++) {

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.html
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.html
@@ -5,11 +5,14 @@
 </ion-header>
 
 <ion-content>
+  <ion-button (click)="previousWeek()">Previous Week</ion-button>
+  <ion-button (click)="nextWeek()">Next Week</ion-button>
   <app-week-view
     [accountId]="accountId"
     [userId]="userId"
     [projects]="(projects$ | async) || []"
     [entries]="(entries$ | async) || []"
     [availableProjects]="(projects$ | async) || []"
+    [weekStart]="currentWeekStart"
   ></app-week-view>
 </ion-content>

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.spec.ts
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.spec.ts
@@ -55,4 +55,20 @@ describe("TimesheetPage", () => {
       done();
     });
   });
+
+  it("should advance to the next week", () => {
+    const start = new Date(component.currentWeekStart);
+    component.nextWeek();
+    expect(+component.currentWeekStart).toBe(
+      +start + 7 * 24 * 60 * 60 * 1000,
+    );
+  });
+
+  it("should go back to the previous week", () => {
+    const start = new Date(component.currentWeekStart);
+    component.previousWeek();
+    expect(+component.currentWeekStart).toBe(
+      +start - 7 * 24 * 60 * 60 * 1000,
+    );
+  });
 });

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.ts
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.ts
@@ -44,6 +44,7 @@ export class TimesheetPage implements OnInit {
   entries$!: Observable<TimeEntry[]>;
   accountId: string = "";
   userId: string = "";
+  currentWeekStart: Date = this.startOfWeek(new Date());
 
   constructor(
     private store: Store<AppState>,
@@ -74,5 +75,25 @@ export class TimesheetPage implements OnInit {
     this.store.dispatch(
       TimeTrackingActions.loadProjects({accountId: this.accountId}),
     );
+  }
+
+  startOfWeek(date: Date): Date {
+    const d = new Date(date);
+    d.setHours(0, 0, 0, 0);
+    const day = d.getDay();
+    d.setDate(d.getDate() - day);
+    return d;
+  }
+
+  previousWeek() {
+    const prev = new Date(this.currentWeekStart);
+    prev.setDate(prev.getDate() - 7);
+    this.currentWeekStart = prev;
+  }
+
+  nextWeek() {
+    const next = new Date(this.currentWeekStart);
+    next.setDate(next.getDate() + 7);
+    this.currentWeekStart = next;
   }
 }


### PR DESCRIPTION
## Summary
- add week change functionality to `TimesheetPage`
- show Previous/Next week buttons in the timesheet page
- recalculate dates in `WeekViewComponent` when the week changes
- add tests for the new week navigation logic

## Testing
- `ng test --watch=false` *(fails: Could not find module '@angular-devkit/build-angular:karma')*

------
https://chatgpt.com/codex/tasks/task_e_6881bb06eb08832693844c8da80e4a46