### PR TITLE
Implement weekly time entry loading

### DIFF
--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.html
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.html
@@ -5,9 +5,20 @@
 </ion-header>
 
 <ion-content>
+  <ion-grid>
+    <ion-row class="ion-justify-content-between ion-padding">
+      <ion-col size="auto">
+        <ion-button fill="clear" (click)="previousWeek()">Prev</ion-button>
+      </ion-col>
+      <ion-col size="auto">
+        <ion-button fill="clear" (click)="nextWeek()">Next</ion-button>
+      </ion-col>
+    </ion-row>
+  </ion-grid>
   <app-week-view
     [accountId]="accountId"
     [userId]="userId"
+    [weekStart]="currentWeekStart"
     [projects]="(projects$ | async) || []"
     [entries]="(entries$ | async) || []"
     [availableProjects]="(projects$ | async) || []"

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.spec.ts
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.spec.ts
@@ -8,6 +8,7 @@ import {
   selectEntries,
   selectProjects,
 } from "../../../../state/selectors/time-tracking.selectors";
+import * as TimeTrackingActions from "../../../../state/actions/time-tracking.actions";
 
 describe("TimesheetPage", () => {
   let component: TimesheetPage;
@@ -32,6 +33,8 @@ describe("TimesheetPage", () => {
     store.overrideSelector(selectProjects, []);
     store.overrideSelector(selectEntries, []);
 
+    spyOn(store, "dispatch").and.callThrough();
+
     fixture = TestBed.createComponent(TimesheetPage);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -54,5 +57,11 @@ describe("TimesheetPage", () => {
       expect(e).toEqual([]);
       done();
     });
+  });
+
+  it("should dispatch load entries on init", () => {
+    const action = (store.dispatch as jasmine.Spy).calls.mostRecent().args[0];
+    expect(action.type).toBe(TimeTrackingActions.loadTimeEntries.type);
+    expect(action.weekStart).toEqual(component.currentWeekStart);
   });
 });

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.ts
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.ts
@@ -44,6 +44,12 @@ export class TimesheetPage implements OnInit {
   entries$!: Observable<TimeEntry[]>;
   accountId: string = "";
   userId: string = "";
+  currentWeekStart: Date = (() => {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    d.setDate(d.getDate() - d.getDay());
+    return d;
+  })();
 
   constructor(
     private store: Store<AppState>,
@@ -62,17 +68,34 @@ export class TimesheetPage implements OnInit {
       .subscribe((user) => {
         this.userId = user?.uid ?? "";
         if (this.userId) {
-          this.store.dispatch(
-            TimeTrackingActions.loadTimeEntries({
-              accountId: this.accountId,
-              userId: this.userId,
-            }),
-          );
+          this.loadEntries();
         }
       });
 
     this.store.dispatch(
       TimeTrackingActions.loadProjects({accountId: this.accountId}),
     );
+  }
+
+  private loadEntries() {
+    this.store.dispatch(
+      TimeTrackingActions.loadTimeEntries({
+        accountId: this.accountId,
+        userId: this.userId,
+        weekStart: this.currentWeekStart,
+      }),
+    );
+  }
+
+  nextWeek() {
+    this.currentWeekStart = new Date(this.currentWeekStart);
+    this.currentWeekStart.setDate(this.currentWeekStart.getDate() + 7);
+    this.loadEntries();
+  }
+
+  previousWeek() {
+    this.currentWeekStart = new Date(this.currentWeekStart);
+    this.currentWeekStart.setDate(this.currentWeekStart.getDate() - 7);
+    this.loadEntries();
   }
 }

--- a/src/app/state/actions/time-tracking.actions.ts
+++ b/src/app/state/actions/time-tracking.actions.ts
@@ -55,7 +55,7 @@ export const saveTimeEntryFailure = createAction(
 
 export const loadTimeEntries = createAction(
   "[Time Tracking] Load Time Entries",
-  props<{accountId: string; userId: string}>(),
+  props<{accountId: string; userId: string; weekStart: Date}>(),
 );
 
 export const loadTimeEntriesSuccess = createAction(

--- a/src/app/state/effects/time-tracking.effects.ts
+++ b/src/app/state/effects/time-tracking.effects.ts
@@ -71,11 +71,20 @@ export class TimeTrackingEffects {
   loadEntries$ = createEffect(() =>
     this.actions$.pipe(
       ofType(TimeTrackingActions.loadTimeEntries),
-      mergeMap(({accountId, userId}) =>
+      mergeMap(({accountId, userId, weekStart}) =>
         this.service.getUserEntries(accountId, userId).pipe(
-          map((entries) =>
-            TimeTrackingActions.loadTimeEntriesSuccess({entries}),
-          ),
+          map((entries) => {
+            const start = new Date(weekStart);
+            const end = new Date(start);
+            end.setDate(start.getDate() + 7);
+            const filtered = entries.filter((e) => {
+              const d = e.date.toDate();
+              return d >= start && d < end;
+            });
+            return TimeTrackingActions.loadTimeEntriesSuccess({
+              entries: filtered,
+            });
+          }),
           catchError((error) =>
             of(TimeTrackingActions.loadTimeEntriesFailure({error})),
           ),


### PR DESCRIPTION
## Summary
- filter time entries to the selected week
- expose currentWeekStart in TimesheetPage and dispatch `loadTimeEntries`
- add week navigation to the timesheet template
- test that the correct action is dispatched

## Testing
- `npm test` *(fails: Chrome not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6881bb0d12d083269e0c43db0542ba79