### PR TITLE
Add volunteer project trigger for group accounts

### DIFF
--- a/functions/src/database/accounts/triggers/onCreate/index.ts
+++ b/functions/src/database/accounts/triggers/onCreate/index.ts
@@ -1,0 +1,57 @@
+/**
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ ********************************************************************************/
+
+import {
+  onDocumentCreated,
+  FirestoreEvent,
+} from "firebase-functions/v2/firestore";
+import * as logger from "firebase-functions/logger";
+import {QueryDocumentSnapshot} from "firebase-admin/firestore";
+
+export const onCreateAccount = onDocumentCreated(
+  "accounts/{accountId}",
+  async (
+    event: FirestoreEvent<QueryDocumentSnapshot | undefined, {accountId: string}>,
+  ) => {
+    if (!event.data) {
+      logger.error("No document data found in create event");
+      return;
+    }
+
+    const accountId = event.params.accountId;
+    const data = event.data.data();
+
+    if (
+      data.type === "group" &&
+      (data.groupType === "Nonprofit" || data.groupType === "Community")
+    ) {
+      try {
+        await event.data.ref.collection("projects").add({
+          name: "Volunteer",
+          accountId,
+          archived: false,
+        });
+        logger.info(`Created Volunteer project for account ${accountId}`);
+      } catch (error) {
+        logger.error("Error creating Volunteer project:", error);
+      }
+    }
+  },
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -42,6 +42,7 @@ export {createUserProfile} from "./auth/user/triggers/onCreate";
 export {onUserRecordDeletion} from "./auth/user/triggers/onDelete";
 
 // Account triggers
+export {onCreateAccount} from "./database/accounts/triggers/onCreate";
 export {onUpdateAccount} from "./database/accounts/triggers/onUpdate";
 
 // Related accounts triggers

--- a/functions/test/account.spec.ts
+++ b/functions/test/account.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ ********************************************************************************/
+// functions/test/account.spec.ts
+
+import {expect} from "chai";
+import * as sinon from "sinon";
+const proxyquire = require("proxyquire");
+
+describe("onCreateAccount", () => {
+  function setup() {
+    const addStub = sinon.stub().resolves();
+    const collectionStub = sinon.stub().returns({add: addStub});
+
+    let handler: any;
+    proxyquire("../src/database/accounts/triggers/onCreate", {
+      "firebase-functions/logger": {info: sinon.stub(), error: sinon.stub()},
+      "firebase-functions/v2/firestore": {
+        onDocumentCreated: (_cfg: any, fn: any) => {
+          handler = fn;
+          return fn;
+        },
+      },
+    });
+
+    return {handler, addStub, collectionStub};
+  }
+
+  it("creates a Volunteer project for qualifying accounts", async () => {
+    const {handler, addStub, collectionStub} = setup();
+    const snapshot = {
+      data: () => ({type: "group", groupType: "Nonprofit"}),
+      ref: {collection: collectionStub},
+    };
+    await handler({data: snapshot, params: {accountId: "a"}});
+    expect(collectionStub.calledWith("projects")).to.be.true;
+    expect(
+      addStub.calledWith({name: "Volunteer", accountId: "a", archived: false}),
+    ).to.be.true;
+  });
+
+  it("does nothing for other account types", async () => {
+    const {handler, addStub, collectionStub} = setup();
+    const snapshot = {
+      data: () => ({type: "user"}),
+      ref: {collection: collectionStub},
+    };
+    await handler({data: snapshot, params: {accountId: "a"}});
+    expect(addStub.notCalled).to.be.true;
+  });
+});


### PR DESCRIPTION
## Summary
- add account onCreate trigger to create default Volunteer project
- expose new trigger in functions export
- test creation logic for account onCreate

## Testing
- `TS_NODE_PROJECT=tsconfig.test.json npx mocha -r ts-node/register test/account.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68830968fec48326a5265eb6e00703b1