### PR TITLE
Validate time entry hours

### DIFF
--- a/src/app/modules/time-tracking/components/week-view/week-view.component.spec.ts
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.spec.ts
@@ -105,6 +105,25 @@ describe("WeekViewComponent", () => {
     expect(store.dispatch).not.toHaveBeenCalled();
   });
 
+  it("should not dispatch when hours are outside 0-24", () => {
+    store.dispatch.calls.reset();
+    component.onHoursChange(component.projects[0], component.weekStart, {
+      target: {value: "-1"},
+    } as any);
+    component.onHoursChange(component.projects[0], component.weekStart, {
+      target: {value: "25"},
+    } as any);
+    expect(store.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("should not dispatch when project is undefined", () => {
+    store.dispatch.calls.reset();
+    component.onHoursChange(undefined as any, component.weekStart, {
+      target: {value: "1"},
+    } as any);
+    expect(store.dispatch).not.toHaveBeenCalled();
+  });
+
   it("should calculate initial totals", () => {
     expect(component.rowTotals["p1"]).toBe(1);
     expect(component.rowTotals["p2"]).toBe(0);
@@ -124,9 +143,9 @@ describe("WeekViewComponent", () => {
   });
 
   it("should update header dates when weekStart changes", () => {
-    const initialHeader: string = fixture.nativeElement.querySelectorAll(
-      "thead th",
-    )[1].textContent.trim();
+    const initialHeader: string = fixture.nativeElement
+      .querySelectorAll("thead th")[1]
+      .textContent.trim();
     const nextWeek = new Date(component.weekStart);
     nextWeek.setDate(nextWeek.getDate() + 7);
     component.weekStart = nextWeek;
@@ -134,9 +153,9 @@ describe("WeekViewComponent", () => {
       weekStart: new SimpleChange(null, nextWeek, false),
     });
     fixture.detectChanges();
-    const newHeader: string = fixture.nativeElement.querySelectorAll(
-      "thead th",
-    )[1].textContent.trim();
+    const newHeader: string = fixture.nativeElement
+      .querySelectorAll("thead th")[1]
+      .textContent.trim();
     expect(newHeader).not.toBe(initialHeader);
   });
 });

--- a/src/app/modules/time-tracking/components/week-view/week-view.component.ts
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.ts
@@ -90,10 +90,10 @@ export class WeekViewComponent implements OnInit, OnChanges {
 
   onHoursChange(project: Project, day: Date, event: Event) {
     const target = event.target as HTMLInputElement;
-    if (!target) return;
+    if (!target || !project || !project.id) return;
 
     const hours = Number(target.value);
-    if (isNaN(hours)) {
+    if (isNaN(hours) || hours < 0 || hours > 24) {
       return;
     }
     const existing = this.getEntry(project.id, day);


### PR DESCRIPTION
## Summary
- validate hours range in `onHoursChange`
- skip dispatch when hours invalid or project missing
- add unit tests for invalid hours and missing project

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68830b0fd99483269111c08b3abde1c0