### PR TITLE
Add onCreateAccount trigger tests

### DIFF
--- a/functions/src/database/accounts/triggers/onCreate/index.ts
+++ b/functions/src/database/accounts/triggers/onCreate/index.ts
@@ -1,0 +1,48 @@
+import {
+  onDocumentCreated,
+  FirestoreEvent,
+} from "firebase-functions/v2/firestore";
+import {admin} from "../../../../utils/firebase";
+import * as logger from "firebase-functions/logger";
+import {QueryDocumentSnapshot} from "firebase-admin/firestore";
+
+const db = admin.firestore();
+
+export const onCreateAccount = onDocumentCreated(
+  {document: "accounts/{accountId}", region: "us-central1"},
+  handleAccountCreate,
+);
+
+async function handleAccountCreate(
+  event: FirestoreEvent<QueryDocumentSnapshot | undefined, {accountId: string}>,
+) {
+  const snapshot = event.data;
+  const accountId = event.params.accountId;
+  if (!snapshot) {
+    logger.error("No document data found in create event");
+    return;
+  }
+
+  const account = snapshot.data() as any;
+  const groupType = account.groupDetails?.groupType;
+  if (groupType !== "Nonprofit" && groupType !== "Community") {
+    logger.info(`No volunteer project needed for groupType ${groupType}`);
+    return;
+  }
+
+  try {
+    await db
+      .collection("accounts")
+      .doc(accountId)
+      .collection("projects")
+      .add({
+        name: "Volunteer",
+        accountId,
+        createdAt: admin.firestore.FieldValue.serverTimestamp(),
+        createdBy: accountId,
+      });
+    logger.info(`Volunteer project created for account ${accountId}`);
+  } catch (error) {
+    logger.error("Error creating volunteer project:", error);
+  }
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -43,6 +43,7 @@ export {onUserRecordDeletion} from "./auth/user/triggers/onDelete";
 
 // Account triggers
 export {onUpdateAccount} from "./database/accounts/triggers/onUpdate";
+export {onCreateAccount} from "./database/accounts/triggers/onCreate";
 
 // Related accounts triggers
 export {onCreateRelatedAccount} from "./database/accounts/relatedAccounts/triggers/onCreate";

--- a/functions/test/onCreateAccount.spec.ts
+++ b/functions/test/onCreateAccount.spec.ts
@@ -1,0 +1,50 @@
+import {expect} from "chai";
+import * as sinon from "sinon";
+const proxyquire = require("proxyquire");
+
+describe("onCreateAccount", () => {
+  function setup() {
+    const addStub = sinon.stub().resolves();
+    const projectsCollectionStub = sinon.stub().returns({add: addStub});
+    const docStub = sinon.stub().returns({collection: projectsCollectionStub});
+    const collectionStub = sinon.stub().returns({doc: docStub});
+    const firestoreFn: any = sinon.stub().returns({collection: collectionStub});
+    firestoreFn.FieldValue = {serverTimestamp: sinon.stub()};
+    const adminStub = {firestore: firestoreFn};
+
+    let handler: any;
+    proxyquire("../src/database/accounts/triggers/onCreate", {
+      "../../../../utils/firebase": {admin: adminStub},
+      "firebase-functions/logger": {info: sinon.stub(), error: sinon.stub()},
+      "firebase-functions/v2/firestore": {
+        onDocumentCreated: (_cfg: any, fn: any) => {
+          handler = fn;
+          return fn;
+        },
+      },
+    });
+
+    return {handler, addStub, collectionStub, docStub, projectsCollectionStub};
+  }
+
+  it("adds volunteer project for supported group types", async () => {
+    const {handler, addStub, collectionStub, docStub, projectsCollectionStub} = setup();
+    const snapshot = {
+      data: () => ({groupDetails: {groupType: "Nonprofit"}}),
+    } as any;
+    await handler({data: snapshot, params: {accountId: "a"}} as any);
+    expect(collectionStub.calledWith("accounts")).to.be.true;
+    expect(docStub.calledWith("a")).to.be.true;
+    expect(projectsCollectionStub.calledWith("projects")).to.be.true;
+    expect(addStub.calledOnce).to.be.true;
+  });
+
+  it("does not add project for unsupported group types", async () => {
+    const {handler, addStub} = setup();
+    const snapshot = {
+      data: () => ({groupDetails: {groupType: "Business"}}),
+    } as any;
+    await handler({data: snapshot, params: {accountId: "a"}} as any);
+    expect(addStub.called).to.be.false;
+  });
+});


### PR DESCRIPTION
## Summary
- create `onCreateAccount` cloud function to add Volunteer project
- export function
- test volunteer project creation on account create

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688309e2cd6883269863cb684fab19a9