### PR TITLE
Implement dynamic rows in week view

### DIFF
--- a/src/app/modules/time-tracking/components/week-view/week-view.component.html
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.html
@@ -1,15 +1,5 @@
 <h2>Week of {{ weekStart | date: 'MMM d' }}</h2>
-<button (click)="toggleProjectDropdown()">Add Project</button>
-<select *ngIf="dropdownOpen" (change)="addProjectById($event)">
-  <option value="">Select...</option>
-  <option
-    *ngFor="let proj of availableProjects"
-    [value]="proj.id"
-    [disabled]="isSelected(proj.id)"
-  >
-    {{ proj.name }}
-  </option>
-</select>
+<button (click)="addRow()">Add Row</button>
 
 <table class="week-grid">
   <thead>
@@ -20,16 +10,34 @@
     </tr>
   </thead>
   <tbody>
-    <tr *ngFor="let project of projects">
-      <td>{{ project.name }}</td>
+    <tr *ngFor="let row of rows; let i = index">
+      <td>
+        <ng-container *ngIf="availableProjects.length > 1; else single">
+          <select [value]="row.projectId" (change)="addProjectById(i, $event)">
+            <option value="">Select...</option>
+            <option
+              *ngFor="let proj of availableProjects"
+              [value]="proj.id"
+              [disabled]="isSelected(proj.id, i)"
+            >
+              {{ proj.name }}
+            </option>
+          </select>
+        </ng-container>
+        <ng-template #single>
+          {{ availableProjects[0]?.name }}
+        </ng-template>
+        <button (click)="removeRow(i)">Remove</button>
+      </td>
       <td *ngFor="let day of days">
         <input
           type="number"
-          [value]="getEntry(project.id, day)?.hours"
-          (change)="onHoursChange(project, day, $event)"
+          [value]="row.projectId ? getEntry(row.projectId, day)?.hours : ''"
+          (change)="onHoursChange(i, day, $event)"
+          [disabled]="!row.projectId"
         />
       </td>
-      <td>{{ rowTotals[project.id] || 0 }}</td>
+      <td>{{ rowTotals[i] || 0 }}</td>
     </tr>
   </tbody>
   <tfoot>

--- a/src/app/modules/time-tracking/components/week-view/week-view.component.spec.ts
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.spec.ts
@@ -22,14 +22,12 @@ describe("WeekViewComponent", () => {
 
     component.userId = "test";
 
-    component.projects = [
+    component.availableProjects = [
       {id: "p1", name: "Project 1"} as any,
       {id: "p2", name: "Project 2"} as any,
-    ];
-    component.availableProjects = [
-      ...component.projects,
       {id: "p3", name: "Project 3"} as any,
     ];
+    component.rows = [{projectId: "p1"}, {projectId: "p2"}];
 
     const today = new Date();
     component.weekStart = today;
@@ -51,7 +49,7 @@ describe("WeekViewComponent", () => {
     expect(component).toBeTruthy();
   });
 
-  it("should render a row for each project", () => {
+  it("should render a row for each configured row", () => {
     const rows = fixture.nativeElement.querySelectorAll("tbody tr");
     expect(rows.length).toBe(2);
   });
@@ -71,7 +69,7 @@ describe("WeekViewComponent", () => {
   it("should include userId when creating new entry", () => {
     const nextDay = new Date(component.weekStart);
     nextDay.setDate(nextDay.getDate() + 1);
-    component.onHoursChange(component.projects[0], nextDay, {
+    component.onHoursChange(0, nextDay, {
       target: {value: "3"},
     } as any);
 
@@ -85,7 +83,7 @@ describe("WeekViewComponent", () => {
 
   it("should add a row when a project is added", () => {
     const mockEvent = {target: {value: "p3"}} as any;
-    component.addProjectById(mockEvent);
+    component.addProjectById(1, mockEvent);
     fixture.detectChanges();
     const rows = fixture.nativeElement.querySelectorAll("tbody tr");
     expect(rows.length).toBe(3);
@@ -93,7 +91,7 @@ describe("WeekViewComponent", () => {
 
   it("should not dispatch when hours empty for new entry", () => {
     const mockEvent = {target: {value: "p3"}} as any;
-    component.addProjectById(mockEvent);
+    component.addProjectById(1, mockEvent);
     fixture.detectChanges();
     store.dispatch.calls.reset();
     const inputs = fixture.nativeElement.querySelectorAll(
@@ -106,8 +104,8 @@ describe("WeekViewComponent", () => {
   });
 
   it("should calculate initial totals", () => {
-    expect(component.rowTotals["p1"]).toBe(1);
-    expect(component.rowTotals["p2"]).toBe(0);
+    expect(component.rowTotals[0]).toBe(1);
+    expect(component.rowTotals[1]).toBe(0);
     expect(component.columnTotals[0]).toBe(1);
     expect(component.totalHours).toBe(1);
   });
@@ -118,15 +116,15 @@ describe("WeekViewComponent", () => {
     input.value = "5";
     input.dispatchEvent(new Event("change"));
     fixture.detectChanges();
-    expect(component.rowTotals["p1"]).toBe(5);
+    expect(component.rowTotals[0]).toBe(5);
     expect(component.columnTotals[0]).toBe(5);
     expect(component.totalHours).toBe(5);
   });
 
   it("should update header dates when weekStart changes", () => {
-    const initialHeader: string = fixture.nativeElement.querySelectorAll(
-      "thead th",
-    )[1].textContent.trim();
+    const initialHeader: string = fixture.nativeElement
+      .querySelectorAll("thead th")[1]
+      .textContent.trim();
     const nextWeek = new Date(component.weekStart);
     nextWeek.setDate(nextWeek.getDate() + 7);
     component.weekStart = nextWeek;
@@ -134,9 +132,9 @@ describe("WeekViewComponent", () => {
       weekStart: new SimpleChange(null, nextWeek, false),
     });
     fixture.detectChanges();
-    const newHeader: string = fixture.nativeElement.querySelectorAll(
-      "thead th",
-    )[1].textContent.trim();
+    const newHeader: string = fixture.nativeElement
+      .querySelectorAll("thead th")[1]
+      .textContent.trim();
     expect(newHeader).not.toBe(initialHeader);
   });
 });


### PR DESCRIPTION
## Summary
- extend `WeekViewComponent` to manage rows of project selectors
- prevent duplicate selection, auto-add default when only one project is available
- update the template to use per-row dropdowns and add/remove controls
- adjust tests for the new behaviour

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68830aef1e4c8326b245ba09a93f5387