### PR TITLE
Improve project loading in timesheet

### DIFF
--- a/src/app/core/services/time-tracking.service.spec.ts
+++ b/src/app/core/services/time-tracking.service.spec.ts
@@ -137,4 +137,18 @@ describe("TimeTrackingService", () => {
       entry,
     );
   });
+
+  it("should delete a time entry using FirestoreService", async () => {
+    const entry = {id: "e1", accountId: "testAccountId"} as TimeEntry;
+    firestoreSpy.deleteDocument = jasmine
+      .createSpy()
+      .and.returnValue(Promise.resolve());
+
+    await service.deleteTimeEntry(entry);
+
+    expect(firestoreSpy.deleteDocument).toHaveBeenCalledWith(
+      `accounts/${entry.accountId}/timeEntries`,
+      entry.id,
+    );
+  });
 });

--- a/src/app/core/services/time-tracking.service.ts
+++ b/src/app/core/services/time-tracking.service.ts
@@ -90,4 +90,11 @@ export class TimeTrackingService {
       entry,
     );
   }
+
+  deleteTimeEntry(entry: TimeEntry): Promise<void> {
+    return this.firestore.deleteDocument(
+      `accounts/${entry.accountId}/timeEntries`,
+      entry.id,
+    );
+  }
 }

--- a/src/app/modules/time-tracking/components/week-view/week-view.component.ts
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.ts
@@ -100,6 +100,14 @@ export class WeekViewComponent implements OnInit, OnChanges {
     if (!existing && (!target.value || hours === 0)) {
       return;
     }
+    if (existing && hours === 0) {
+      this.entries = this.entries.filter((e) => e !== existing);
+      this.updateTotals();
+      this.store.dispatch(
+        TimeTrackingActions.deleteTimeEntry({entry: existing}),
+      );
+      return;
+    }
     const entry: TimeEntry = {
       id: existing ? existing.id : "",
       accountId: this.accountId,

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.html
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.html
@@ -19,9 +19,8 @@
     [accountId]="accountId"
     [userId]="userId"
     [weekStart]="currentWeekStart"
-    [projects]="(projects$ | async) || []"
-    [entries]="(entries$ | async) || []"
-    [availableProjects]="(projects$ | async) || []"
-    [weekStart]="currentWeekStart"
+    [projects]="projects"
+    [entries]="entries"
+    [availableProjects]="availableProjects"
   ></app-week-view>
 </ion-content>

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.ts
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.ts
@@ -42,6 +42,9 @@ import {AppState} from "../../../../state/app.state";
 export class TimesheetPage implements OnInit {
   projects$!: Observable<Project[]>;
   entries$!: Observable<TimeEntry[]>;
+  projects: Project[] = [];
+  availableProjects: Project[] = [];
+  entries: TimeEntry[] = [];
   accountId: string = "";
   userId: string = "";
   currentWeekStart: Date = (() => {
@@ -61,6 +64,23 @@ export class TimesheetPage implements OnInit {
 
     this.projects$ = this.store.select(selectProjects);
     this.entries$ = this.store.select(selectEntries);
+
+    this.projects$.subscribe((projects) => {
+      this.availableProjects = projects;
+    });
+
+    this.entries$.subscribe((entries) => {
+      this.entries = entries;
+      const ids = new Set(entries.map((e) => e.projectId));
+      for (const id of Array.from(ids)) {
+        if (!this.projects.some((p) => p.id === id)) {
+          const proj = this.availableProjects.find((p) => p.id === id);
+          if (proj) {
+            this.projects.push(proj);
+          }
+        }
+      }
+    });
 
     this.store
       .select(selectAuthUser)
@@ -98,23 +118,23 @@ export class TimesheetPage implements OnInit {
     this.currentWeekStart.setDate(this.currentWeekStart.getDate() - 7);
     this.loadEntries();
   }
-//   startOfWeek(date: Date): Date {
-//     const d = new Date(date);
-//     d.setHours(0, 0, 0, 0);
-//     const day = d.getDay();
-//     d.setDate(d.getDate() - day);
-//     return d;
-//   }
+  //   startOfWeek(date: Date): Date {
+  //     const d = new Date(date);
+  //     d.setHours(0, 0, 0, 0);
+  //     const day = d.getDay();
+  //     d.setDate(d.getDate() - day);
+  //     return d;
+  //   }
 
-//   previousWeek() {
-//     const prev = new Date(this.currentWeekStart);
-//     prev.setDate(prev.getDate() - 7);
-//     this.currentWeekStart = prev;
-//   }
+  //   previousWeek() {
+  //     const prev = new Date(this.currentWeekStart);
+  //     prev.setDate(prev.getDate() - 7);
+  //     this.currentWeekStart = prev;
+  //   }
 
-//   nextWeek() {
-//     const next = new Date(this.currentWeekStart);
-//     next.setDate(next.getDate() + 7);
-//     this.currentWeekStart = next;
-//   }
+  //   nextWeek() {
+  //     const next = new Date(this.currentWeekStart);
+  //     next.setDate(next.getDate() + 7);
+  //     this.currentWeekStart = next;
+  //   }
 }

--- a/src/app/state/actions/time-tracking.actions.ts
+++ b/src/app/state/actions/time-tracking.actions.ts
@@ -53,6 +53,21 @@ export const saveTimeEntryFailure = createAction(
   props<{error: any}>(),
 );
 
+export const deleteTimeEntry = createAction(
+  "[Time Tracking] Delete Time Entry",
+  props<{entry: TimeEntry}>(),
+);
+
+export const deleteTimeEntrySuccess = createAction(
+  "[Time Tracking] Delete Time Entry Success",
+  props<{entryId: string}>(),
+);
+
+export const deleteTimeEntryFailure = createAction(
+  "[Time Tracking] Delete Time Entry Failure",
+  props<{error: any}>(),
+);
+
 export const loadTimeEntries = createAction(
   "[Time Tracking] Load Time Entries",
   props<{accountId: string; userId: string; weekStart: Date}>(),

--- a/src/app/state/effects/time-tracking.effects.ts
+++ b/src/app/state/effects/time-tracking.effects.ts
@@ -68,6 +68,22 @@ export class TimeTrackingEffects {
     ),
   );
 
+  deleteEntry$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(TimeTrackingActions.deleteTimeEntry),
+      mergeMap(({entry}) =>
+        from(this.service.deleteTimeEntry(entry)).pipe(
+          map(() =>
+            TimeTrackingActions.deleteTimeEntrySuccess({entryId: entry.id}),
+          ),
+          catchError((error) =>
+            of(TimeTrackingActions.deleteTimeEntryFailure({error})),
+          ),
+        ),
+      ),
+    ),
+  );
+
   loadEntries$ = createEffect(() =>
     this.actions$.pipe(
       ofType(TimeTrackingActions.loadTimeEntries),

--- a/src/app/state/reducers/time-tracking.reducer.ts
+++ b/src/app/state/reducers/time-tracking.reducer.ts
@@ -69,6 +69,20 @@ export const timeTrackingReducer = createReducer(
     loading: false,
     error,
   })),
+  on(TimeTrackingActions.deleteTimeEntry, (state) => ({
+    ...state,
+    loading: true,
+  })),
+  on(TimeTrackingActions.deleteTimeEntrySuccess, (state) => ({
+    ...state,
+    loading: false,
+    error: null,
+  })),
+  on(TimeTrackingActions.deleteTimeEntryFailure, (state, {error}) => ({
+    ...state,
+    loading: false,
+    error,
+  })),
   on(TimeTrackingActions.loadTimeEntries, (state) => ({
     ...state,
     loading: true,


### PR DESCRIPTION
## Summary
- add actions and effects to delete time entries
- delete entries when hours set to 0
- ensure projects referenced in entries are automatically displayed
- track selected projects and entries on the Timesheet page
- test delete logic in time tracking service

## Testing
- `npm test` *(fails: Chrome missing)*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68830af8b15c8326b63097195e65ae2c