### PR TITLE
Add admin guard and manage projects link

### DIFF
--- a/src/app/core/guards/admin.guard.ts
+++ b/src/app/core/guards/admin.guard.ts
@@ -1,0 +1,40 @@
+import { Injectable } from "@angular/core";
+import { ActivatedRouteSnapshot, Router } from "@angular/router";
+import { firstValueFrom } from "rxjs";
+import { Store } from "@ngrx/store";
+import { selectAuthUser } from "../../state/selectors/auth.selectors";
+import { selectRelatedAccountsByAccountId } from "../../state/selectors/account.selectors";
+
+@Injectable({ providedIn: "root" })
+export class AdminGuard {
+  constructor(private store: Store, private router: Router) {}
+
+  async canActivate(route: ActivatedRouteSnapshot): Promise<boolean> {
+    const accountId = route.paramMap.get("accountId");
+    const authUser = await firstValueFrom(this.store.select(selectAuthUser));
+    if (!accountId || !authUser) {
+      await this.router.navigate(["/auth/login"]);
+      return false;
+    }
+
+    if (authUser.uid === accountId) {
+      return true;
+    }
+
+    const relatedAccounts = await firstValueFrom(
+      this.store.select(selectRelatedAccountsByAccountId(accountId))
+    );
+
+    const relation = relatedAccounts.find((ra) => ra.id === authUser.uid);
+    const isAdmin =
+      relation?.status === "accepted" &&
+      (relation.access === "admin" || relation.access === "moderator");
+
+    if (isAdmin) {
+      return true;
+    }
+
+    await this.router.navigate(["/"]);
+    return false;
+  }
+}

--- a/src/app/modules/account/account-routing.module.ts
+++ b/src/app/modules/account/account-routing.module.ts
@@ -20,6 +20,7 @@
 import {NgModule} from "@angular/core";
 import {RouterModule, Routes} from "@angular/router";
 import {AuthGuard} from "../../core/guards/auth.guard";
+import {AdminGuard} from "../../core/guards/admin.guard";
 import {DetailsPage} from "./pages/details/details.page";
 import {EditPage} from "./pages/edit/edit.page";
 import {RegistrationPage} from "./pages/registration/registration.page";
@@ -30,6 +31,7 @@ import {ListPage} from "./relatedAccount/pages/list/list.page";
 import {ListingsListPage} from "./relatedListings/pages/listings-list/listings-list.page";
 import {RoleManagementPage} from "./pages/role-management/role-management.page";
 import {RoleHierarchyPage} from "./pages/role-hierarchy/role-hierarchy.page";
+import {ManageProjectsPage} from "./pages/manage-projects/manage-projects.page";
 
 const routes: Routes = [
   {
@@ -80,6 +82,11 @@ const routes: Routes = [
     path: ":accountId/hierarchy",
     component: RoleHierarchyPage,
     canActivate: [AuthGuard],
+  },
+  {
+    path: ":accountId/manage-projects",
+    component: ManageProjectsPage,
+    canActivate: [AuthGuard, AdminGuard],
   },
 ];
 

--- a/src/app/modules/account/account.module.ts
+++ b/src/app/modules/account/account.module.ts
@@ -57,6 +57,7 @@ import {RelatedListingsComponent} from "./pages/details/components/related-listi
 import {ListingsListPage} from "./relatedListings/pages/listings-list/listings-list.page";
 import {RoleManagementPage} from "./pages/role-management/role-management.page";
 import {RoleHierarchyPage} from "./pages/role-hierarchy/role-hierarchy.page";
+import {ManageProjectsPage} from "./pages/manage-projects/manage-projects.page";
 import {SafeUrlPipe} from "../../shared/pipes/safe-url.pipe";
 import {GroupCalendarComponent} from "./pages/details/components/group-calendar/group-calendar.component";
 
@@ -90,6 +91,7 @@ import {GroupCalendarComponent} from "./pages/details/components/group-calendar/
     RelatedListingsComponent,
     RoleManagementPage,
     RoleHierarchyPage,
+    ManageProjectsPage,
     GroupCalendarComponent,
     SafeUrlPipe,
   ],

--- a/src/app/modules/account/pages/manage-projects/manage-projects.page.html
+++ b/src/app/modules/account/pages/manage-projects/manage-projects.page.html
@@ -1,0 +1,9 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Manage Projects</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <p class="ion-padding">Project management placeholder.</p>
+</ion-content>

--- a/src/app/modules/account/pages/manage-projects/manage-projects.page.ts
+++ b/src/app/modules/account/pages/manage-projects/manage-projects.page.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from "@angular/core";
+
+@Component({
+  selector: "app-manage-projects",
+  templateUrl: "./manage-projects.page.html",
+  styleUrls: ["./manage-projects.page.scss"],
+})
+export class ManageProjectsPage implements OnInit {
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/shared/components/menu/menu.component.ts
+++ b/src/app/shared/components/menu/menu.component.ts
@@ -171,6 +171,11 @@ export class MenuComponent implements OnInit, OnDestroy {
         url: "/account/settings",
         icon: "settings",
       },
+      {
+        title: this.translate.instant("menu.manage_projects"),
+        url: `/account/${this.user?.uid}/manage-projects`,
+        icon: "folder-open",
+      },
       // {
       //   title: this.translate.instant("menu.dashboard"),
       //   url: `user-dashboard/${this.user?.uid}`,

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -20,7 +20,8 @@
     "profile": "Profile",
     "users": "Users",
     "settings": "Settings",
-    "dashboard": "Dashboard"
+    "dashboard": "Dashboard",
+    "manage_projects": "Manage Projects"
   },
   "user": {
     "login": {

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -20,7 +20,8 @@
     "profile": "Profil",
     "users": "Utilisateurs",
     "settings": "Paramètres",
-    "dashboard": "Tableau de bord"
+    "dashboard": "Tableau de bord",
+    "manage_projects": "Gérer les projets"
   },
   "user": {
     "login": {


### PR DESCRIPTION
## Summary
- add AdminGuard to restrict account admin pages
- add ManageProjectsPage and routing for `/account/:accountId/manage-projects`
- show "Manage Projects" link in the user menu
- update translations for the new menu item

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68830b1d7e7c8326a29cac5c52c520bd