### PR TITLE
Filter archived projects

### DIFF
--- a/src/app/core/services/time-tracking.service.spec.ts
+++ b/src/app/core/services/time-tracking.service.spec.ts
@@ -58,11 +58,18 @@ describe("TimeTrackingService", () => {
     const snapshotActions = [
       {
         payload: {
-          doc: {data: () => ({name: "Proj", accountId}), id: "1"},
+          doc: {
+            data: () => ({name: "Proj", accountId, archived: false}),
+            id: "1",
+          },
         },
       },
     ];
-    (afsSpy.collection as any).and.callFake((name: string) => {
+    const whereSpy = jasmine.createSpy("where").and.returnValue({} as any);
+    (afsSpy.collection as any).and.callFake((name: string, fn?: any) => {
+      if (fn) {
+        fn({where: whereSpy});
+      }
       return {
         snapshotChanges: () => of(snapshotActions as any),
       } as any;
@@ -74,7 +81,9 @@ describe("TimeTrackingService", () => {
     });
     expect(afsSpy.collection).toHaveBeenCalledWith(
       `accounts/${accountId}/projects` as any,
+      jasmine.any(Function),
     );
+    expect(whereSpy).toHaveBeenCalledWith("archived", "==", false);
   });
 
   it("should retrieve user time entries", (done) => {

--- a/src/app/core/services/time-tracking.service.ts
+++ b/src/app/core/services/time-tracking.service.ts
@@ -38,7 +38,9 @@ export class TimeTrackingService {
 
   getProjects(accountId: string): Observable<Project[]> {
     return this.afs
-      .collection<Project>(`accounts/${accountId}/projects`)
+      .collection<Project>(`accounts/${accountId}/projects`, (ref) =>
+        ref.where("archived", "==", false),
+      )
       .snapshotChanges()
       .pipe(
         map((actions) =>


### PR DESCRIPTION
## Summary
- hide archived projects when loading from Firestore
- test that query filters archived projects

## Testing
- `npm run test` *(fails: Chrome not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68830b269e208326a49120f00f88c5ef