### PR TITLE
Add AGPL headers to onCreate trigger and test

### DIFF
--- a/functions/src/database/accounts/triggers/onCreate/index.ts
+++ b/functions/src/database/accounts/triggers/onCreate/index.ts
@@ -17,6 +17,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
  ********************************************************************************/
+// functions/src/database/accounts/triggers/onCreate/index.ts
 
 import {
   onDocumentCreated,

--- a/functions/test/onCreateAccount.spec.ts
+++ b/functions/test/onCreateAccount.spec.ts
@@ -1,3 +1,24 @@
+/**
+ * Nonprofit Social Networking Platform: Allowing Users and Organizations to Collaborate.
+ * Copyright (C) 2023  ASCENDynamics NFP
+ *
+ * This file is part of Nonprofit Social Networking Platform.
+ *
+ * Nonprofit Social Networking Platform is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nonprofit Social Networking Platform is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.org/licenses/>.
+ *******************************************************************************/
+// functions/test/onCreateAccount.spec.ts
+
 import {expect} from "chai";
 import * as sinon from "sinon";
 const proxyquire = require("proxyquire");
@@ -28,7 +49,8 @@ describe("onCreateAccount", () => {
   }
 
   it("adds volunteer project for supported group types", async () => {
-    const {handler, addStub, collectionStub, docStub, projectsCollectionStub} = setup();
+    const {handler, addStub, collectionStub, docStub, projectsCollectionStub} =
+      setup();
     const snapshot = {
       data: () => ({groupDetails: {groupType: "Nonprofit"}}),
     } as any;


### PR DESCRIPTION
## Summary
- add AGPL header to `onCreateAccount.spec.ts`
- include AGPL header path comment in account creation trigger

## Testing
- `npm test` *(fails: Found 1 load error)*
- `npm --prefix functions test` *(fails: `firebase` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688312130ed483269a3968576dda5b77