### PR TITLE
Fix week view hours validation

### DIFF
--- a/src/app/modules/time-tracking/components/week-view/week-view.component.spec.ts
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.spec.ts
@@ -117,10 +117,10 @@ describe("WeekViewComponent", () => {
 
   it("should not dispatch when hours are outside 0-24", () => {
     store.dispatch.calls.reset();
-    component.onHoursChange(component.projects[0], component.weekStart, {
+    component.onHoursChange(0, component.weekStart, {
       target: {value: "-1"},
     } as any);
-    component.onHoursChange(component.projects[0], component.weekStart, {
+    component.onHoursChange(0, component.weekStart, {
       target: {value: "25"},
     } as any);
     expect(store.dispatch).not.toHaveBeenCalled();
@@ -128,9 +128,23 @@ describe("WeekViewComponent", () => {
 
   it("should not dispatch when project is undefined", () => {
     store.dispatch.calls.reset();
-    component.onHoursChange(undefined as any, component.weekStart, {
+    component.rows.push({projectId: null});
+    const index = component.rows.length - 1;
+    component.onHoursChange(index, component.weekStart, {
       target: {value: "1"},
     } as any);
+    expect(store.dispatch).not.toHaveBeenCalled();
+  });
+
+  it("should skip validation when project is not selected", () => {
+    store.dispatch.calls.reset();
+    component.rows.push({projectId: null});
+    const index = component.rows.length - 1;
+    spyOn(component, "getEntry");
+    component.onHoursChange(index, component.weekStart, {
+      target: {value: "5"},
+    } as any);
+    expect(component.getEntry).not.toHaveBeenCalled();
     expect(store.dispatch).not.toHaveBeenCalled();
   });
 

--- a/src/app/modules/time-tracking/components/week-view/week-view.component.ts
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.ts
@@ -103,14 +103,15 @@ export class WeekViewComponent implements OnInit, OnChanges {
 
   onHoursChange(rowIndex: number, day: Date, event: Event) {
     const target = event.target as HTMLInputElement;
-    if (!target || !project || !project.id) return;
+    if (!target) return;
+
+    const projectId = this.rows[rowIndex]?.projectId;
+    if (!projectId) {
+      return;
+    }
 
     const hours = Number(target.value);
     if (isNaN(hours) || hours < 0 || hours > 24) {
-      return;
-    }
-    const projectId = this.rows[rowIndex].projectId;
-    if (!projectId) {
       return;
     }
     const existing = this.getEntry(projectId, day);

--- a/src/app/state/actions/time-tracking.actions.ts
+++ b/src/app/state/actions/time-tracking.actions.ts
@@ -82,18 +82,3 @@ export const loadTimeEntriesFailure = createAction(
   "[Time Tracking] Load Time Entries Failure",
   props<{error: any}>(),
 );
-
-export const deleteTimeEntry = createAction(
-  "[Time Tracking] Delete Time Entry",
-  props<{entry: TimeEntry}>(),
-);
-
-export const deleteTimeEntrySuccess = createAction(
-  "[Time Tracking] Delete Time Entry Success",
-  props<{entryId: string}>(),
-);
-
-export const deleteTimeEntryFailure = createAction(
-  "[Time Tracking] Delete Time Entry Failure",
-  props<{error: any}>(),
-);


### PR DESCRIPTION
## Summary
- ensure hours are validated only if a project is selected
- update unit tests for hours validation logic
- clean up duplicate actions to allow compilation

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68831738d12483268180e872d1c75d42