### PR TITLE
Remove duplicate time tracking actions

### DIFF
--- a/src/app/state/actions/time-tracking.actions.ts
+++ b/src/app/state/actions/time-tracking.actions.ts
@@ -53,21 +53,6 @@ export const saveTimeEntryFailure = createAction(
   props<{error: any}>(),
 );
 
-export const deleteTimeEntry = createAction(
-  "[Time Tracking] Delete Time Entry",
-  props<{entry: TimeEntry}>(),
-);
-
-export const deleteTimeEntrySuccess = createAction(
-  "[Time Tracking] Delete Time Entry Success",
-  props<{entryId: string}>(),
-);
-
-export const deleteTimeEntryFailure = createAction(
-  "[Time Tracking] Delete Time Entry Failure",
-  props<{error: any}>(),
-);
-
 export const loadTimeEntries = createAction(
   "[Time Tracking] Load Time Entries",
   props<{accountId: string; userId: string; weekStart: Date}>(),

--- a/src/app/state/effects/time-tracking.effects.ts
+++ b/src/app/state/effects/time-tracking.effects.ts
@@ -68,22 +68,6 @@ export class TimeTrackingEffects {
     ),
   );
 
-  deleteEntry$ = createEffect(() =>
-    this.actions$.pipe(
-      ofType(TimeTrackingActions.deleteTimeEntry),
-      mergeMap(({entry}) =>
-        from(this.service.deleteTimeEntry(entry)).pipe(
-          map(() =>
-            TimeTrackingActions.deleteTimeEntrySuccess({entryId: entry.id}),
-          ),
-          catchError((error) =>
-            of(TimeTrackingActions.deleteTimeEntryFailure({error})),
-          ),
-        ),
-      ),
-    ),
-  );
-
   loadEntries$ = createEffect(() =>
     this.actions$.pipe(
       ofType(TimeTrackingActions.loadTimeEntries),

--- a/src/app/state/reducers/time-tracking.reducer.ts
+++ b/src/app/state/reducers/time-tracking.reducer.ts
@@ -69,20 +69,6 @@ export const timeTrackingReducer = createReducer(
     loading: false,
     error,
   })),
-  on(TimeTrackingActions.deleteTimeEntry, (state) => ({
-    ...state,
-    loading: true,
-  })),
-  on(TimeTrackingActions.deleteTimeEntrySuccess, (state) => ({
-    ...state,
-    loading: false,
-    error: null,
-  })),
-  on(TimeTrackingActions.deleteTimeEntryFailure, (state, {error}) => ({
-    ...state,
-    loading: false,
-    error,
-  })),
   on(TimeTrackingActions.loadTimeEntries, (state) => ({
     ...state,
     loading: true,


### PR DESCRIPTION
## Summary
- keep a single deleteTimeEntry action group
- drop duplicated deleteEntry$ effect logic
- clean up reducer to use one set of delete handlers

## Testing
- `npm test` *(fails: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_68831744d3288326a041cbc98769964b