### PR TITLE
Add initialRows to week view

### DIFF
--- a/src/app/modules/time-tracking/components/week-view/week-view.component.spec.ts
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.spec.ts
@@ -117,10 +117,10 @@ describe("WeekViewComponent", () => {
 
   it("should not dispatch when hours are outside 0-24", () => {
     store.dispatch.calls.reset();
-    component.onHoursChange(component.projects[0], component.weekStart, {
+    component.onHoursChange(0, component.weekStart, {
       target: {value: "-1"},
     } as any);
-    component.onHoursChange(component.projects[0], component.weekStart, {
+    component.onHoursChange(0, component.weekStart, {
       target: {value: "25"},
     } as any);
     expect(store.dispatch).not.toHaveBeenCalled();

--- a/src/app/modules/time-tracking/components/week-view/week-view.component.ts
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.ts
@@ -43,6 +43,7 @@ export class WeekViewComponent implements OnInit, OnChanges {
   @Input() entries: TimeEntry[] = [];
   @Input() accountId: string = "";
   @Input() userId: string = "";
+  @Input() initialRows: {projectId: string | null}[] = [];
 
   /** Selected rows referencing project ids */
   rows: {projectId: string | null}[] = [];
@@ -58,7 +59,9 @@ export class WeekViewComponent implements OnInit, OnChanges {
   ngOnInit() {
     this.calculateDays();
     if (this.rows.length === 0) {
-      if (this.availableProjects.length === 1) {
+      if (this.initialRows && this.initialRows.length > 0) {
+        this.rows = [...this.initialRows];
+      } else if (this.availableProjects.length === 1) {
         this.rows.push({projectId: this.availableProjects[0].id});
       } else {
         this.rows.push({projectId: null});
@@ -73,7 +76,14 @@ export class WeekViewComponent implements OnInit, OnChanges {
     if (changes["weekStart"]) {
       this.calculateDays();
     }
-    if (changes["availableProjects"] && this.rows.length === 0) {
+    if (changes["initialRows"] && this.rows.length === 0) {
+      const rows: {projectId: string | null}[] =
+        changes["initialRows"].currentValue;
+      if (rows && rows.length > 0) {
+        this.rows = [...rows];
+        this.updateTotals();
+      }
+    } else if (changes["availableProjects"] && this.rows.length === 0) {
       if (this.availableProjects.length === 1) {
         this.rows.push({projectId: this.availableProjects[0].id});
       }
@@ -103,7 +113,7 @@ export class WeekViewComponent implements OnInit, OnChanges {
 
   onHoursChange(rowIndex: number, day: Date, event: Event) {
     const target = event.target as HTMLInputElement;
-    if (!target || !project || !project.id) return;
+    if (!target) return;
 
     const hours = Number(target.value);
     if (isNaN(hours) || hours < 0 || hours > 24) {

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.html
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.html
@@ -19,7 +19,7 @@
     [accountId]="accountId"
     [userId]="userId"
     [weekStart]="currentWeekStart"
-    [projects]="projects"
+    [initialRows]="initialRows"
     [entries]="entries"
     [availableProjects]="availableProjects"
   ></app-week-view>

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.ts
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.ts
@@ -42,9 +42,9 @@ import {AppState} from "../../../../state/app.state";
 export class TimesheetPage implements OnInit {
   projects$!: Observable<Project[]>;
   entries$!: Observable<TimeEntry[]>;
-  projects: Project[] = [];
   availableProjects: Project[] = [];
   entries: TimeEntry[] = [];
+  initialRows: {projectId: string}[] = [];
   accountId: string = "";
   userId: string = "";
   currentWeekStart: Date = (() => {
@@ -72,14 +72,7 @@ export class TimesheetPage implements OnInit {
     this.entries$.subscribe((entries) => {
       this.entries = entries;
       const ids = new Set(entries.map((e) => e.projectId));
-      for (const id of Array.from(ids)) {
-        if (!this.projects.some((p) => p.id === id)) {
-          const proj = this.availableProjects.find((p) => p.id === id);
-          if (proj) {
-            this.projects.push(proj);
-          }
-        }
-      }
+      this.initialRows = Array.from(ids).map((id) => ({projectId: id}));
     });
 
     this.store

--- a/src/app/state/actions/time-tracking.actions.ts
+++ b/src/app/state/actions/time-tracking.actions.ts
@@ -82,18 +82,3 @@ export const loadTimeEntriesFailure = createAction(
   "[Time Tracking] Load Time Entries Failure",
   props<{error: any}>(),
 );
-
-export const deleteTimeEntry = createAction(
-  "[Time Tracking] Delete Time Entry",
-  props<{entry: TimeEntry}>(),
-);
-
-export const deleteTimeEntrySuccess = createAction(
-  "[Time Tracking] Delete Time Entry Success",
-  props<{entryId: string}>(),
-);
-
-export const deleteTimeEntryFailure = createAction(
-  "[Time Tracking] Delete Time Entry Failure",
-  props<{error: any}>(),
-);


### PR DESCRIPTION
## Summary
- load timesheet week view rows from previous entries
- setup `initialRows` input on week view component
- drop unused projects property in timesheet
- update week view test expectations
- remove duplicate delete actions

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6883173f986c832682eb8d3f55ee47e6