### PR TITLE
Fix delete time entry actions

### DIFF
--- a/src/app/state/actions/time-tracking.actions.ts
+++ b/src/app/state/actions/time-tracking.actions.ts
@@ -67,3 +67,18 @@ export const loadTimeEntriesFailure = createAction(
   "[Time Tracking] Load Time Entries Failure",
   props<{error: any}>(),
 );
+
+export const deleteTimeEntry = createAction(
+  "[Time Tracking] Delete Time Entry",
+  props<{entry: TimeEntry}>(),
+);
+
+export const deleteTimeEntrySuccess = createAction(
+  "[Time Tracking] Delete Time Entry Success",
+  props<{entryId: string}>(),
+);
+
+export const deleteTimeEntryFailure = createAction(
+  "[Time Tracking] Delete Time Entry Failure",
+  props<{error: any}>(),
+);


### PR DESCRIPTION
## Summary
- reintroduce delete time entry actions

## Testing
- `npm test` *(fails: Chrome not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688320edc21c8326b8f6fc93f42c920b