### PR TITLE
Add group admin project link

### DIFF
--- a/src/app/modules/account/pages/details/components/hero/hero.component.html
+++ b/src/app/modules/account/pages/details/components/hero/hero.component.html
@@ -63,6 +63,15 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
         Donate</ion-button
       >
       <ion-button
+        *ngIf="isGroupAdmin"
+        color="primary"
+        fill="outline"
+        size="small"
+        [routerLink]="'/account/' + account.id + '/projects'"
+      >
+        <ion-icon name="folder-open"></ion-icon> Projects
+      </ion-button>
+      <ion-button
         *ngIf="isProfileOwner"
         color="primary"
         fill="outline"

--- a/src/app/modules/account/pages/details/components/hero/hero.component.ts
+++ b/src/app/modules/account/pages/details/components/hero/hero.component.ts
@@ -32,6 +32,7 @@ import {ImageUploadModalComponent} from "../../../../../../shared/components/ima
 export class HeroComponent {
   @Input() account!: Account; // Changed from Partial<Account> to Account to ensure properties are defined
   @Input() isProfileOwner: boolean = false;
+  @Input() isGroupAdmin = false;
 
   constructor(private modalController: ModalController) {}
 

--- a/src/app/modules/account/pages/details/details.page.html
+++ b/src/app/modules/account/pages/details/details.page.html
@@ -29,6 +29,7 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
       id="profile"
       [account]="account"
       [isProfileOwner]="(isProfileOwner$ | async) ?? false"
+      [isGroupAdmin]="(isGroupAdmin$ | async) ?? false"
     ></app-hero>
 
     <div class="tabs">

--- a/src/app/modules/account/pages/details/details.page.ts
+++ b/src/app/modules/account/pages/details/details.page.ts
@@ -54,6 +54,7 @@ export class DetailsPage implements OnInit, ViewWillEnter {
   relatedAccounts$!: Observable<RelatedAccount[]>;
   relatedListings$!: Observable<RelatedListing[]>;
   isProfileOwner$!: Observable<boolean>;
+  isGroupAdmin$!: Observable<boolean>;
   error$!: Observable<any>;
 
   constructor(
@@ -138,6 +139,20 @@ export class DetailsPage implements OnInit, ViewWillEnter {
               return account.id === authUser.uid;
             }
             return false;
+          }),
+        );
+
+        this.isGroupAdmin$ = combineLatest([
+          this.authUser$,
+          this.relatedAccounts$,
+        ]).pipe(
+          map(([currentUser, relatedAccounts]) => {
+            if (!currentUser) return false;
+            const rel = relatedAccounts.find((ra) => ra.id === currentUser.uid);
+            return (
+              rel?.status === "accepted" &&
+              (rel.access === "admin" || rel.access === "moderator")
+            );
           }),
         );
       }

--- a/src/app/shared/components/menu/menu.component.ts
+++ b/src/app/shared/components/menu/menu.component.ts
@@ -171,11 +171,6 @@ export class MenuComponent implements OnInit, OnDestroy {
         url: "/account/settings",
         icon: "settings",
       },
-      {
-        title: this.translate.instant("menu.manage_projects"),
-        url: `/account/${this.user?.uid}/projects`,
-        icon: "folder-open",
-      },
       // {
       //   title: this.translate.instant("menu.dashboard"),
       //   url: `user-dashboard/${this.user?.uid}`,


### PR DESCRIPTION
## Summary
- drop Manage Projects from main menu
- compute group admin status on account Details page
- pass group admin info to Hero component
- show Projects button in the profile hero when allowed

## Testing
- `npm test` *(fails: Error: Found 1 load error)*
- `npm run lint` *(fails: 282 problems)*

------
https://chatgpt.com/codex/tasks/task_e_688320e9d2248326be64360d5f1a31e8