### PR TITLE
Fix Firestore listener cleanup

### DIFF
--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.spec.ts
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.spec.ts
@@ -76,4 +76,11 @@ describe("TimesheetPage", () => {
     component.previousWeek();
     expect(+component.currentWeekStart).toBe(+start - 7 * 24 * 60 * 60 * 1000);
   });
+
+  it("should dispatch clear action on destroy", () => {
+    component.ngOnDestroy();
+    expect(store.dispatch).toHaveBeenCalledWith(
+      TimeTrackingActions.clearTimeTrackingSubscriptions(),
+    );
+  });
 });

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.ts
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.ts
@@ -19,7 +19,7 @@
  ********************************************************************************/
 // src/app/modules/time-tracking/pages/timesheet/timesheet.page.ts
 
-import {Component, OnInit} from "@angular/core";
+import {Component, OnInit, OnDestroy} from "@angular/core";
 import {Store} from "@ngrx/store";
 import {ActivatedRoute} from "@angular/router";
 import {Observable} from "rxjs";
@@ -39,7 +39,7 @@ import {AppState} from "../../../../state/app.state";
   templateUrl: "./timesheet.page.html",
   styleUrls: ["./timesheet.page.scss"],
 })
-export class TimesheetPage implements OnInit {
+export class TimesheetPage implements OnInit, OnDestroy {
   projects$!: Observable<Project[]>;
   entries$!: Observable<TimeEntry[]>;
   availableProjects: Project[] = [];
@@ -110,6 +110,10 @@ export class TimesheetPage implements OnInit {
     this.currentWeekStart = new Date(this.currentWeekStart);
     this.currentWeekStart.setDate(this.currentWeekStart.getDate() - 7);
     this.loadEntries();
+  }
+
+  ngOnDestroy() {
+    this.store.dispatch(TimeTrackingActions.clearTimeTrackingSubscriptions());
   }
   //   startOfWeek(date: Date): Date {
   //     const d = new Date(date);

--- a/src/app/state/actions/time-tracking.actions.ts
+++ b/src/app/state/actions/time-tracking.actions.ts
@@ -82,3 +82,7 @@ export const deleteTimeEntryFailure = createAction(
   "[Time Tracking] Delete Time Entry Failure",
   props<{error: any}>(),
 );
+
+export const clearTimeTrackingSubscriptions = createAction(
+  "[Time Tracking] Clear Subscriptions",
+);

--- a/src/app/state/effects/time-tracking.effects.ts
+++ b/src/app/state/effects/time-tracking.effects.ts
@@ -21,7 +21,14 @@
 
 import {Injectable} from "@angular/core";
 import {Actions, createEffect, ofType} from "@ngrx/effects";
-import {mergeMap, map, catchError, tap} from "rxjs/operators";
+import {
+  mergeMap,
+  map,
+  catchError,
+  tap,
+  switchMap,
+  takeUntil,
+} from "rxjs/operators";
 import {of, from} from "rxjs";
 import {TimeTrackingService} from "../../core/services/time-tracking.service";
 import * as TimeTrackingActions from "../actions/time-tracking.actions";
@@ -38,8 +45,13 @@ export class TimeTrackingEffects {
   loadProjects$ = createEffect(() =>
     this.actions$.pipe(
       ofType(TimeTrackingActions.loadProjects),
-      mergeMap(({accountId}) =>
+      switchMap(({accountId}) =>
         this.service.getProjects(accountId).pipe(
+          takeUntil(
+            this.actions$.pipe(
+              ofType(TimeTrackingActions.clearTimeTrackingSubscriptions),
+            ),
+          ),
           map((projects) =>
             TimeTrackingActions.loadProjectsSuccess({projects}),
           ),
@@ -103,8 +115,13 @@ export class TimeTrackingEffects {
   loadEntries$ = createEffect(() =>
     this.actions$.pipe(
       ofType(TimeTrackingActions.loadTimeEntries),
-      mergeMap(({accountId, userId, weekStart}) =>
+      switchMap(({accountId, userId, weekStart}) =>
         this.service.getUserEntries(accountId, userId).pipe(
+          takeUntil(
+            this.actions$.pipe(
+              ofType(TimeTrackingActions.clearTimeTrackingSubscriptions),
+            ),
+          ),
           map((entries) => {
             const start = new Date(weekStart);
             const end = new Date(start);

--- a/src/app/state/reducers/time-tracking.reducer.ts
+++ b/src/app/state/reducers/time-tracking.reducer.ts
@@ -99,4 +99,8 @@ export const timeTrackingReducer = createReducer(
     loading: false,
     error,
   })),
+
+  on(TimeTrackingActions.clearTimeTrackingSubscriptions, () => ({
+    ...initialState,
+  })),
 );


### PR DESCRIPTION
## Summary
- ensure Firestore listeners aren't duplicated by switching to `switchMap`
- add `clearTimeTrackingSubscriptions` action and reducer handling
- cancel listeners when navigating away from timesheet page
- test dispatch of the clear action on destroy

## Testing
- `npm install`
- `CHROME_BIN=$(which chromium-browser) npm test` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed.)*

------
https://chatgpt.com/codex/tasks/task_e_688326a6ab7083269dda3f3fa1b2a322