### PR TITLE
Refactor project management page to use store

### DIFF
--- a/src/app/modules/account/pages/projects/projects.page.html
+++ b/src/app/modules/account/pages/projects/projects.page.html
@@ -5,19 +5,36 @@
 </ion-header>
 
 <ion-content>
+  <ion-loading
+    *ngIf="loading$ | async"
+    message="Loading projects..."
+  ></ion-loading>
+  <ion-text color="danger" *ngIf="error$ | async as error">
+    {{ error }}
+  </ion-text>
   <div *ngIf="(isGroupAdmin$ | async)">
     <ion-item>
-      <ion-input placeholder="New project" [(ngModel)]="newProjectName"></ion-input>
+      <ion-input
+        placeholder="New project"
+        [(ngModel)]="newProjectName"
+      ></ion-input>
       <ion-button (click)="addProject()">Add</ion-button>
     </ion-item>
   </div>
 
-  <ion-list>
+  <ion-list *ngIf="!(loading$ | async)">
     <ion-list-header>Active Projects</ion-list-header>
-    <ion-item *ngFor="let proj of (activeProjects$ | async); trackBy: trackById">
+    <ion-item
+      *ngFor="let proj of (activeProjects$ | async); trackBy: trackById"
+    >
       <ng-container *ngIf="(isGroupAdmin$ | async); else view">
-        <ion-input [value]="proj.name" (ionChange)="updateProject(proj, $event.detail.value)"></ion-input>
-        <ion-button slot="end" (click)="toggleArchive(proj, true)">Archive</ion-button>
+        <ion-input
+          [value]="proj.name"
+          (ionChange)="updateProject(proj, $event.detail.value)"
+        ></ion-input>
+        <ion-button slot="end" (click)="toggleArchive(proj, true)"
+          >Archive</ion-button
+        >
       </ng-container>
       <ng-template #view>
         <ion-label>{{proj.name}}</ion-label>
@@ -25,11 +42,18 @@
     </ion-item>
   </ion-list>
 
-  <ion-list>
+  <ion-list *ngIf="!(loading$ | async)">
     <ion-list-header>Archived Projects</ion-list-header>
-    <ion-item *ngFor="let proj of (archivedProjects$ | async); trackBy: trackById">
+    <ion-item
+      *ngFor="let proj of (archivedProjects$ | async); trackBy: trackById"
+    >
       <ion-label>{{proj.name}}</ion-label>
-      <ion-button *ngIf="(isGroupAdmin$ | async)" slot="end" (click)="toggleArchive(proj, false)">Unarchive</ion-button>
+      <ion-button
+        *ngIf="(isGroupAdmin$ | async)"
+        slot="end"
+        (click)="toggleArchive(proj, false)"
+        >Unarchive</ion-button
+      >
     </ion-item>
   </ion-list>
 </ion-content>

--- a/src/app/modules/account/pages/projects/projects.page.spec.ts
+++ b/src/app/modules/account/pages/projects/projects.page.spec.ts
@@ -3,34 +3,29 @@ import {IonicModule} from "@ionic/angular";
 import {ProjectsPage} from "./projects.page";
 import {provideMockStore, MockStore} from "@ngrx/store/testing";
 import {ActivatedRoute} from "@angular/router";
-import {ProjectService} from "../../../../core/services/project.service";
 import {SuccessHandlerService} from "../../../../core/services/success-handler.service";
 import {ErrorHandlerService} from "../../../../core/services/error-handler.service";
 import {selectAuthUser} from "../../../../state/selectors/auth.selectors";
 import {selectRelatedAccountsByAccountId} from "../../../../state/selectors/account.selectors";
+import {
+  selectProjectsByAccount,
+  selectActiveProjectsByAccount,
+} from "../../../../state/selectors/projects.selectors";
+import * as ProjectsActions from "../../../../state/actions/projects.actions";
 import {of} from "rxjs";
 
 describe("ProjectsPage", () => {
   let component: ProjectsPage;
   let fixture: ComponentFixture<ProjectsPage>;
   let store: MockStore;
-  let serviceSpy: jasmine.SpyObj<ProjectService>;
   let errorHandler: {handleFirebaseAuthError: jasmine.Spy};
 
   beforeEach(async () => {
-    serviceSpy = jasmine.createSpyObj("ProjectService", [
-      "getProjects",
-      "createProject",
-      "updateProject",
-      "setArchived",
-    ]);
-
     await TestBed.configureTestingModule({
       declarations: [ProjectsPage],
       imports: [IonicModule.forRoot()],
       providers: [
         provideMockStore(),
-        {provide: ProjectService, useValue: serviceSpy},
         {
           provide: SuccessHandlerService,
           useValue: {handleSuccess: jasmine.createSpy("handleSuccess")},
@@ -49,7 +44,11 @@ describe("ProjectsPage", () => {
     store = TestBed.inject(MockStore);
     store.overrideSelector(selectAuthUser, {uid: "u1"} as any);
     store.overrideSelector(selectRelatedAccountsByAccountId("acc1"), []);
-    serviceSpy.getProjects.and.returnValue(of([]));
+    store.overrideSelector(selectProjectsByAccount("acc1"), []);
+    store.overrideSelector(selectActiveProjectsByAccount("acc1"), []);
+
+    spyOn(store, "dispatch").and.callThrough();
+
     errorHandler = TestBed.inject(ErrorHandlerService) as any;
 
     fixture = TestBed.createComponent(ProjectsPage);
@@ -62,14 +61,15 @@ describe("ProjectsPage", () => {
   });
 
   it("should load projects for account", () => {
-    expect(serviceSpy.getProjects).toHaveBeenCalledWith("acc1");
+    expect(store.dispatch).toHaveBeenCalledWith(
+      ProjectsActions.loadProjects({accountId: "acc1"}),
+    );
   });
 
   it("should show error when adding a project with duplicate name", () => {
-    // simulate existing active project
-    serviceSpy.getProjects.and.returnValue(
-      of([{id: "p1", name: "Alpha"} as any]),
-    );
+    store.overrideSelector(selectActiveProjectsByAccount("acc1"), [
+      {id: "p1", name: "Alpha"} as any,
+    ]);
     fixture = TestBed.createComponent(ProjectsPage);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -78,13 +78,16 @@ describe("ProjectsPage", () => {
     component.addProject();
 
     expect(errorHandler.handleFirebaseAuthError).toHaveBeenCalled();
-    expect(serviceSpy.createProject).not.toHaveBeenCalled();
+    expect(store.dispatch).not.toHaveBeenCalledWith(
+      jasmine.objectContaining({type: ProjectsActions.createProject.type}),
+    );
   });
 
   it("should show error when updating to a duplicate name", () => {
-    serviceSpy.getProjects.and.returnValue(
-      of([{id: "p1", name: "Alpha"} as any, {id: "p2", name: "Beta"} as any]),
-    );
+    store.overrideSelector(selectActiveProjectsByAccount("acc1"), [
+      {id: "p1", name: "Alpha"} as any,
+      {id: "p2", name: "Beta"} as any,
+    ]);
     fixture = TestBed.createComponent(ProjectsPage);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -93,6 +96,8 @@ describe("ProjectsPage", () => {
     component.updateProject(project, " alpha ");
 
     expect(errorHandler.handleFirebaseAuthError).toHaveBeenCalled();
-    expect(serviceSpy.updateProject).not.toHaveBeenCalled();
+    expect(store.dispatch).not.toHaveBeenCalledWith(
+      jasmine.objectContaining({type: ProjectsActions.updateProject.type}),
+    );
   });
 });

--- a/src/app/modules/account/pages/projects/projects.page.ts
+++ b/src/app/modules/account/pages/projects/projects.page.ts
@@ -6,7 +6,13 @@ import {Store} from "@ngrx/store";
 import {Project} from "@shared/models/project.model";
 import {selectAuthUser} from "../../../../state/selectors/auth.selectors";
 import {selectRelatedAccountsByAccountId} from "../../../../state/selectors/account.selectors";
-import {ProjectService} from "../../../../core/services/project.service";
+import * as ProjectsActions from "../../../../state/actions/projects.actions";
+import {
+  selectProjectsByAccount,
+  selectActiveProjectsByAccount,
+  selectProjectsLoading,
+  selectProjectsError,
+} from "../../../../state/selectors/projects.selectors";
 import {MetaService} from "../../../../core/services/meta.service";
 import {SuccessHandlerService} from "../../../../core/services/success-handler.service";
 import {ErrorHandlerService} from "../../../../core/services/error-handler.service";
@@ -21,6 +27,8 @@ export class ProjectsPage implements OnInit {
   projects$!: Observable<Project[]>;
   activeProjects$!: Observable<Project[]>;
   archivedProjects$!: Observable<Project[]>;
+  loading$!: Observable<boolean>;
+  error$!: Observable<any>;
   isGroupAdmin$!: Observable<boolean>;
   newProjectName = "";
   /** Lower-cased names of active projects for quick duplicate checks */
@@ -29,7 +37,6 @@ export class ProjectsPage implements OnInit {
   constructor(
     private route: ActivatedRoute,
     private store: Store,
-    private projectService: ProjectService,
     private metaService: MetaService,
     private successHandler: SuccessHandlerService,
     private errorHandler: ErrorHandlerService,
@@ -76,9 +83,9 @@ export class ProjectsPage implements OnInit {
   }
 
   private loadProjects() {
-    this.projects$ = this.projectService.getProjects(this.accountId);
-    this.activeProjects$ = this.projects$.pipe(
-      map((projects) => projects.filter((p) => !p.archived)),
+    this.projects$ = this.store.select(selectProjectsByAccount(this.accountId));
+    this.activeProjects$ = this.store.select(
+      selectActiveProjectsByAccount(this.accountId),
     );
     this.activeProjects$.subscribe((projects) => {
       this.activeProjectNames = projects.map((p) =>
@@ -87,6 +94,12 @@ export class ProjectsPage implements OnInit {
     });
     this.archivedProjects$ = this.projects$.pipe(
       map((projects) => projects.filter((p) => p.archived)),
+    );
+    this.loading$ = this.store.select(selectProjectsLoading);
+    this.error$ = this.store.select(selectProjectsError);
+
+    this.store.dispatch(
+      ProjectsActions.loadProjects({accountId: this.accountId}),
     );
   }
 
@@ -102,13 +115,11 @@ export class ProjectsPage implements OnInit {
       return;
     }
     const project: Project = {name, accountId: this.accountId} as Project;
-    this.projectService
-      .createProject(this.accountId, project)
-      .then(() => {
-        this.newProjectName = "";
-        this.successHandler.handleSuccess("Project created!");
-      })
-      .catch((error) => this.errorHandler.handleFirebaseAuthError(error));
+    this.store.dispatch(
+      ProjectsActions.createProject({accountId: this.accountId, project}),
+    );
+    this.newProjectName = "";
+    this.successHandler.handleSuccess("Project created!");
   }
 
   updateProject(project: Project, name: string) {
@@ -123,22 +134,28 @@ export class ProjectsPage implements OnInit {
       });
       return;
     }
-    this.projectService
-      .updateProject(this.accountId, project.id, {name: trimmed})
-      .then(() => this.successHandler.handleSuccess("Project updated!"))
-      .catch((error) => this.errorHandler.handleFirebaseAuthError(error));
+    this.store.dispatch(
+      ProjectsActions.updateProject({
+        accountId: this.accountId,
+        projectId: project.id,
+        changes: {name: trimmed},
+      }),
+    );
+    this.successHandler.handleSuccess("Project updated!");
   }
 
   toggleArchive(project: Project, archived: boolean) {
     if (!project.id) return;
-    this.projectService
-      .setArchived(this.accountId, project.id, archived)
-      .then(() =>
-        this.successHandler.handleSuccess(
-          archived ? "Project archived" : "Project restored",
-        ),
-      )
-      .catch((error) => this.errorHandler.handleFirebaseAuthError(error));
+    this.store.dispatch(
+      ProjectsActions.updateProject({
+        accountId: this.accountId,
+        projectId: project.id,
+        changes: {archived},
+      }),
+    );
+    this.successHandler.handleSuccess(
+      archived ? "Project archived" : "Project restored",
+    );
   }
 
   trackById(_: number, proj: Project) {

--- a/src/app/state/selectors/projects.selectors.ts
+++ b/src/app/state/selectors/projects.selectors.ts
@@ -36,3 +36,13 @@ export const selectActiveProjectsByAccount = (accountId: string) =>
   createSelector(selectProjectsByAccount(accountId), (projects: Project[]) =>
     projects.filter((p) => !p.archived),
   );
+
+export const selectProjectsLoading = createSelector(
+  selectProjectsState,
+  (state: ProjectsState) => state.loading,
+);
+
+export const selectProjectsError = createSelector(
+  selectProjectsState,
+  (state: ProjectsState) => state.error,
+);


### PR DESCRIPTION
## Summary
- manage projects via NgRx store instead of ProjectService
- expose project loading and error state through new selectors
- update project management page to dispatch actions
- show spinners and errors in project template
- adjust unit tests for new behaviour

## Testing
- `npm run test` *(fails: Chrome not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688333d433bc83268f45e9287f30de05