### PR TITLE
Update group admin checks

### DIFF
--- a/src/app/modules/account/pages/details/details.page.ts
+++ b/src/app/modules/account/pages/details/details.page.ts
@@ -145,14 +145,18 @@ export class DetailsPage implements OnInit, ViewWillEnter {
         this.isGroupAdmin$ = combineLatest([
           this.authUser$,
           this.relatedAccounts$,
+          this.account$,
         ]).pipe(
-          map(([currentUser, relatedAccounts]) => {
+          map(([currentUser, relatedAccounts, account]) => {
             if (!currentUser) return false;
             const rel = relatedAccounts.find((ra) => ra.id === currentUser.uid);
-            return (
+            const isAdmin =
               rel?.status === "accepted" &&
-              (rel.access === "admin" || rel.access === "moderator")
-            );
+              (rel.access === "admin" || rel.access === "moderator");
+            const isOwner =
+              account?.type === "group" &&
+              account.createdBy === currentUser.uid;
+            return isAdmin || isOwner;
           }),
         );
       }


### PR DESCRIPTION
## Summary
- allow group owners to have admin rights on group profile
- include group owner when checking admin for projects list

## Testing
- `npx prettier -w src/app/modules/account/pages/details/details.page.ts src/app/modules/account/pages/projects/projects.page.ts`
- `npm test` *(fails: Cannot find name 'serviceSpy')*

------
https://chatgpt.com/codex/tasks/task_e_688337d275ac8326a63e359cff4fb995