### PR TITLE
Store user time entries in map

### DIFF
--- a/src/app/modules/account/pages/projects/projects.page.spec.ts
+++ b/src/app/modules/account/pages/projects/projects.page.spec.ts
@@ -126,7 +126,13 @@ describe("ProjectsPage", () => {
     tick();
 
     expect(alertController.create).toHaveBeenCalled();
-    expect(serviceSpy.setArchived).toHaveBeenCalledWith("acc1", "p1", true);
+    expect(store.dispatch).toHaveBeenCalledWith(
+      ProjectsActions.updateProject({
+        accountId: "acc1",
+        projectId: "p1",
+        changes: {archived: true},
+      }),
+    );
   }));
 
   it("should not archive the last active project", fakeAsync(() => {
@@ -144,7 +150,13 @@ describe("ProjectsPage", () => {
     tick();
 
     expect(alertController.create).toHaveBeenCalled();
-    expect(serviceSpy.setArchived).not.toHaveBeenCalled();
+    expect(store.dispatch).not.toHaveBeenCalledWith(
+      ProjectsActions.updateProject({
+        accountId: "acc1",
+        projectId: "p1",
+        changes: {archived: true},
+      }),
+    );
     expect(errorHandler.handleFirebaseAuthError).toHaveBeenCalled();
   }));
 });

--- a/src/app/modules/listing/relatedAccount/pages/applicants/applicants.page.spec.ts
+++ b/src/app/modules/listing/relatedAccount/pages/applicants/applicants.page.spec.ts
@@ -163,7 +163,7 @@ describe("ApplicantsPage", () => {
       listings: listingsState,
       auth: {user: mockAuthUser, error: null, loading: false},
       accounts: accountsState,
-      timeTracking: {projects: [], entries: [], loading: false, error: null},
+      timeTracking: {entities: {}, loading: false, error: null},
       projects: {entities: {}, loading: false, error: null},
     };
   }

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.spec.ts
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.spec.ts
@@ -29,7 +29,13 @@ describe("TimesheetPage", () => {
     store = TestBed.inject(MockStore);
     store.overrideSelector(selectAuthUser, {uid: "test"} as any);
     store.overrideSelector(selectActiveProjectsByAccount("acc1"), []);
-    store.overrideSelector(selectEntries, []);
+    const weekStart = (() => {
+      const d = new Date();
+      d.setHours(0, 0, 0, 0);
+      d.setDate(d.getDate() - d.getDay());
+      return d;
+    })();
+    store.overrideSelector(selectEntries("acc1", "test", weekStart), []);
 
     spyOn(store, "dispatch").and.callThrough();
 

--- a/src/app/state/actions/time-tracking.actions.ts
+++ b/src/app/state/actions/time-tracking.actions.ts
@@ -60,12 +60,22 @@ export const loadTimeEntries = createAction(
 
 export const loadTimeEntriesSuccess = createAction(
   "[Time Tracking] Load Time Entries Success",
-  props<{entries: TimeEntry[]}>(),
+  props<{
+    accountId: string;
+    userId: string;
+    weekStart: Date;
+    entries: TimeEntry[];
+  }>(),
 );
 
 export const loadTimeEntriesFailure = createAction(
   "[Time Tracking] Load Time Entries Failure",
-  props<{error: any}>(),
+  props<{
+    accountId: string;
+    userId: string;
+    weekStart: Date;
+    error: any;
+  }>(),
 );
 
 export const deleteTimeEntry = createAction(

--- a/src/app/state/app.state.ts
+++ b/src/app/state/app.state.ts
@@ -23,12 +23,12 @@ import {AccountState} from "./reducers/account.reducer";
 import {AuthState} from "./reducers/auth.reducer";
 import {ListingsState} from "./reducers/listings.reducer";
 import {ProjectsState} from "./reducers/projects.reducer";
-import {TimeTrackingState} from "./reducers/time-tracking.reducer";
+import {TimeEntriesState} from "./reducers/time-tracking.reducer";
 
 export interface AppState {
   accounts: AccountState;
   auth: AuthState;
   listings: ListingsState;
   projects: ProjectsState;
-  timeTracking: TimeTrackingState;
+  timeTracking: TimeEntriesState;
 }

--- a/src/app/state/effects/time-tracking.effects.ts
+++ b/src/app/state/effects/time-tracking.effects.ts
@@ -131,11 +131,21 @@ export class TimeTrackingEffects {
               return d >= start && d < end;
             });
             return TimeTrackingActions.loadTimeEntriesSuccess({
+              accountId,
+              userId,
+              weekStart,
               entries: filtered,
             });
           }),
           catchError((error) =>
-            of(TimeTrackingActions.loadTimeEntriesFailure({error})),
+            of(
+              TimeTrackingActions.loadTimeEntriesFailure({
+                accountId,
+                userId,
+                weekStart,
+                error,
+              }),
+            ),
           ),
         ),
       ),

--- a/src/app/state/selectors/time-tracking.selectors.ts
+++ b/src/app/state/selectors/time-tracking.selectors.ts
@@ -1,18 +1,27 @@
 import {createFeatureSelector, createSelector} from "@ngrx/store";
-import {TimeTrackingState} from "../reducers/time-tracking.reducer";
+import {TimeEntriesState} from "../reducers/time-tracking.reducer";
 
 export const selectTimeTrackingState =
-  createFeatureSelector<TimeTrackingState>("timeTracking");
+  createFeatureSelector<TimeEntriesState>("timeTracking");
 
-export const selectProjects = createSelector(
-  selectTimeTrackingState,
-  (state) => state.projects,
-);
-
-export const selectEntries = createSelector(
-  selectTimeTrackingState,
-  (state) => state.entries,
-);
+export const selectEntries = (
+  accountId: string,
+  userId: string,
+  weekStart?: Date,
+) =>
+  createSelector(selectTimeTrackingState, (state: TimeEntriesState) => {
+    const entries = state.entities[`${accountId}_${userId}`] || [];
+    if (!weekStart) {
+      return entries;
+    }
+    const start = new Date(weekStart);
+    const end = new Date(start);
+    end.setDate(start.getDate() + 7);
+    return entries.filter((e) => {
+      const d = e.date.toDate();
+      return d >= start && d < end;
+    });
+  });
 
 export const selectTimeTrackingLoading = createSelector(
   selectTimeTrackingState,


### PR DESCRIPTION
## Summary
- modify time tracking reducer to keep entries in a keyed map
- extend load time entries actions with context info
- store entries per account/user in reducer
- filter entries via new selector helpers
- adapt effects, components and specs to updated API

## Testing
- `npm install`
- `npm test` *(fails: No Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_6883a5568f648326aff33d0de14393a1