### PR TITLE
Fix lint warnings and test module errors

### DIFF
--- a/functions/src/database/accounts/triggers/onCreate/index.ts
+++ b/functions/src/database/accounts/triggers/onCreate/index.ts
@@ -23,7 +23,6 @@ import {
   onDocumentCreated,
   FirestoreEvent,
 } from "firebase-functions/v2/firestore";
-import {admin} from "../../../../utils/firebase";
 import * as logger from "firebase-functions/logger";
 import {QueryDocumentSnapshot, DocumentData} from "firebase-admin/firestore";
 
@@ -35,7 +34,8 @@ export const onCreateAccount = onDocumentCreated(
 /**
  * Handle creation of a new account document.
  *
- * @param event - Firestore event containing the new account data and params.
+ * @param {FirestoreEvent<QueryDocumentSnapshot | undefined, {accountId: string}>} event -
+ *   Firestore event containing the new account data and params.
  */
 async function handleAccountCreate(
   event: FirestoreEvent<QueryDocumentSnapshot | undefined, {accountId: string}>,

--- a/functions/src/database/timeEntries/triggers/onCreate/index.ts
+++ b/functions/src/database/timeEntries/triggers/onCreate/index.ts
@@ -17,7 +17,10 @@ export const onCreateTimeEntry = onDocumentCreated(
 /**
  * Handle creation of a new time entry document.
  *
- * @param event - Firestore event containing the time entry data and params.
+ * @param {FirestoreEvent<
+ *   QueryDocumentSnapshot | undefined,
+ *   {accountId: string; entryId: string}
+ * >} event - Firestore event containing the time entry data and params.
  */
 async function handleTimeEntryCreate(
   event: FirestoreEvent<

--- a/functions/src/database/timeEntries/triggers/onDelete/index.ts
+++ b/functions/src/database/timeEntries/triggers/onDelete/index.ts
@@ -17,7 +17,10 @@ export const onDeleteTimeEntry = onDocumentDeleted(
 /**
  * Handle deletion of a time entry document.
  *
- * @param event - Firestore event containing the deleted time entry data and params.
+ * @param {FirestoreEvent<
+ *   QueryDocumentSnapshot | undefined,
+ *   {accountId: string; entryId: string}
+ * >} event - Firestore event containing the deleted time entry data and params.
  */
 async function handleTimeEntryDelete(
   event: FirestoreEvent<

--- a/functions/src/database/timeEntries/triggers/onUpdate/index.ts
+++ b/functions/src/database/timeEntries/triggers/onUpdate/index.ts
@@ -42,7 +42,10 @@ export const onUpdateTimeEntry = onDocumentUpdated(
 /**
  * Handle update of a time entry document.
  *
- * @param event - Firestore event containing before and after snapshots and params.
+ * @param {FirestoreEvent<
+ *   Change<QueryDocumentSnapshot> | undefined,
+ *   {accountId: string; entryId: string}
+ * >} event - Firestore event containing before and after snapshots and params.
  */
 async function handleTimeEntryUpdate(
   event: FirestoreEvent<

--- a/src/app/modules/info/pages/about-us/about-us.page.spec.ts
+++ b/src/app/modules/info/pages/about-us/about-us.page.spec.ts
@@ -1,6 +1,7 @@
 import {ComponentFixture, TestBed, waitForAsync} from "@angular/core/testing";
 import {IonicModule} from "@ionic/angular";
 import {RouterTestingModule} from "@angular/router/testing";
+import {SharedModule} from "../../../../shared/shared.module";
 import {AboutUsPage} from "./about-us.page";
 
 describe("AboutUsPage", () => {
@@ -10,7 +11,7 @@ describe("AboutUsPage", () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [AboutUsPage],
-      imports: [IonicModule.forRoot(), RouterTestingModule],
+      imports: [IonicModule.forRoot(), RouterTestingModule, SharedModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AboutUsPage);

--- a/src/app/modules/info/pages/event-calendar/event-calendar.page.spec.ts
+++ b/src/app/modules/info/pages/event-calendar/event-calendar.page.spec.ts
@@ -1,6 +1,7 @@
 import {ComponentFixture, TestBed, waitForAsync} from "@angular/core/testing";
 import {IonicModule} from "@ionic/angular";
 import {RouterTestingModule} from "@angular/router/testing";
+import {SharedModule} from "../../../../shared/shared.module";
 import {EventCalendarPage} from "./event-calendar.page";
 
 describe("EventCalendarPage", () => {
@@ -10,7 +11,7 @@ describe("EventCalendarPage", () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [EventCalendarPage],
-      imports: [IonicModule.forRoot(), RouterTestingModule],
+      imports: [IonicModule.forRoot(), RouterTestingModule, SharedModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(EventCalendarPage);

--- a/src/app/modules/info/pages/services/services.page.spec.ts
+++ b/src/app/modules/info/pages/services/services.page.spec.ts
@@ -1,6 +1,7 @@
 import {ComponentFixture, TestBed, waitForAsync} from "@angular/core/testing";
 import {IonicModule} from "@ionic/angular";
 import {RouterTestingModule} from "@angular/router/testing";
+import {SharedModule} from "../../../../shared/shared.module";
 import {ServicesPage} from "./services.page";
 
 describe("ServicesPage", () => {
@@ -10,7 +11,7 @@ describe("ServicesPage", () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ServicesPage],
-      imports: [IonicModule.forRoot(), RouterTestingModule],
+      imports: [IonicModule.forRoot(), RouterTestingModule, SharedModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ServicesPage);

--- a/src/app/modules/info/pages/startups/startups.page.spec.ts
+++ b/src/app/modules/info/pages/startups/startups.page.spec.ts
@@ -1,6 +1,7 @@
 import {ComponentFixture, TestBed, waitForAsync} from "@angular/core/testing";
 import {IonicModule} from "@ionic/angular";
 import {RouterTestingModule} from "@angular/router/testing";
+import {SharedModule} from "../../../../shared/shared.module";
 import {StartupsPage} from "./startups.page";
 
 describe("StartupsPage", () => {
@@ -10,7 +11,7 @@ describe("StartupsPage", () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [StartupsPage],
-      imports: [IonicModule.forRoot(), RouterTestingModule],
+      imports: [IonicModule.forRoot(), RouterTestingModule, SharedModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(StartupsPage);

--- a/src/app/modules/info/pages/team/team.page.spec.ts
+++ b/src/app/modules/info/pages/team/team.page.spec.ts
@@ -1,6 +1,7 @@
 import {ComponentFixture, TestBed, waitForAsync} from "@angular/core/testing";
 import {IonicModule} from "@ionic/angular";
 import {RouterTestingModule} from "@angular/router/testing";
+import {SharedModule} from "../../../../shared/shared.module";
 import {TeamPage} from "./team.page";
 
 describe("TeamPage", () => {
@@ -10,7 +11,7 @@ describe("TeamPage", () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [TeamPage],
-      imports: [IonicModule.forRoot(), RouterTestingModule],
+      imports: [IonicModule.forRoot(), RouterTestingModule, SharedModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TeamPage);

--- a/src/app/modules/info/pages/think-tank/think-tank.page.spec.ts
+++ b/src/app/modules/info/pages/think-tank/think-tank.page.spec.ts
@@ -1,6 +1,7 @@
 import {ComponentFixture, TestBed, waitForAsync} from "@angular/core/testing";
 import {IonicModule} from "@ionic/angular";
 import {RouterTestingModule} from "@angular/router/testing";
+import {SharedModule} from "../../../../shared/shared.module";
 import {ThinkTankPage} from "./think-tank.page";
 
 describe("ThinkTankPage", () => {
@@ -10,7 +11,7 @@ describe("ThinkTankPage", () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [ThinkTankPage],
-      imports: [IonicModule.forRoot(), RouterTestingModule],
+      imports: [IonicModule.forRoot(), RouterTestingModule, SharedModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ThinkTankPage);

--- a/src/app/modules/time-tracking/pages/timesheet/timesheet.page.spec.ts
+++ b/src/app/modules/time-tracking/pages/timesheet/timesheet.page.spec.ts
@@ -1,6 +1,7 @@
 import {ComponentFixture, TestBed} from "@angular/core/testing";
 import {IonicModule} from "@ionic/angular";
 import {TimesheetPage} from "./timesheet.page";
+import {WeekViewComponent} from "../../components/week-view/week-view.component";
 import {provideMockStore, MockStore} from "@ngrx/store/testing";
 import {ActivatedRoute} from "@angular/router";
 import {selectAuthUser} from "../../../../state/selectors/auth.selectors";
@@ -15,10 +16,14 @@ describe("TimesheetPage", () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [TimesheetPage],
+      declarations: [TimesheetPage, WeekViewComponent],
       imports: [IonicModule.forRoot()],
       providers: [
-        provideMockStore(),
+        provideMockStore({
+          initialState: {
+            timeTracking: {entities: {}, loading: false, error: null},
+          },
+        }),
         {
           provide: ActivatedRoute,
           useValue: {snapshot: {paramMap: {get: () => "acc1"}}},


### PR DESCRIPTION
## Summary
- add missing JSDoc types in firestore triggers and remove unused imports
- include SharedModule in info page specs
- register WeekViewComponent in TimesheetPage tests
- set mock store initial state for TimesheetPage tests

## Testing
- `npm test` *(fails: No Chrome binary available)*
- `npm run lint` *(fails: lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6883aa74be7c83268befae8869ef3d70