### PR TITLE
Add Firestore structure docs

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,3 +57,29 @@ frontend → FirestoreService → Firestore
 3. **Store updates** via Firestore real‑time streams and components react to the new listing information.
 
 The same pattern is used for other account and listing operations ensuring Firestore, Functions and the client stay synchronized.
+
+## Firestore Document Structure
+
+Data in Firestore is organized under each account. Two commonly used collections are `projects` and `timeEntries`.
+
+### Projects
+
+`accounts/{accountId}/projects/{projectId}`
+
+Fields:
+
+- `name` – name of the project.
+- `archived` – whether the project is archived.
+
+### Time Entries
+
+`accounts/{accountId}/timeEntries/{entryId}`
+
+Fields:
+
+- `userId` – ID of the user logging time.
+- `projectId` – ID of the related project (required).
+- `date` – entry date.
+- `hours` – hours recorded.
+
+Each time entry must reference an existing project through its `projectId` field.


### PR DESCRIPTION
## Summary
- document Firestore project and time entry paths in `docs/architecture.md`

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6883ad5d90b08326a5713858249a8467