### PR TITLE
Fix info specs with mock store

### DIFF
--- a/src/app/modules/info/pages/about-us/about-us.page.spec.ts
+++ b/src/app/modules/info/pages/about-us/about-us.page.spec.ts
@@ -2,6 +2,7 @@ import {ComponentFixture, TestBed, waitForAsync} from "@angular/core/testing";
 import {IonicModule} from "@ionic/angular";
 import {RouterTestingModule} from "@angular/router/testing";
 import {SharedModule} from "../../../../shared/shared.module";
+import {provideMockStore} from "@ngrx/store/testing";
 import {AboutUsPage} from "./about-us.page";
 
 describe("AboutUsPage", () => {
@@ -12,6 +13,14 @@ describe("AboutUsPage", () => {
     TestBed.configureTestingModule({
       declarations: [AboutUsPage],
       imports: [IonicModule.forRoot(), RouterTestingModule, SharedModule],
+      providers: [
+        provideMockStore({
+          initialState: {
+            auth: {user: null, loading: false, error: null},
+            projects: {entities: {}, loading: false, error: null},
+          },
+        }),
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AboutUsPage);

--- a/src/app/modules/info/pages/event-calendar/event-calendar.page.spec.ts
+++ b/src/app/modules/info/pages/event-calendar/event-calendar.page.spec.ts
@@ -2,6 +2,7 @@ import {ComponentFixture, TestBed, waitForAsync} from "@angular/core/testing";
 import {IonicModule} from "@ionic/angular";
 import {RouterTestingModule} from "@angular/router/testing";
 import {SharedModule} from "../../../../shared/shared.module";
+import {provideMockStore} from "@ngrx/store/testing";
 import {EventCalendarPage} from "./event-calendar.page";
 
 describe("EventCalendarPage", () => {
@@ -12,6 +13,14 @@ describe("EventCalendarPage", () => {
     TestBed.configureTestingModule({
       declarations: [EventCalendarPage],
       imports: [IonicModule.forRoot(), RouterTestingModule, SharedModule],
+      providers: [
+        provideMockStore({
+          initialState: {
+            auth: {user: null, loading: false, error: null},
+            projects: {entities: {}, loading: false, error: null},
+          },
+        }),
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(EventCalendarPage);

--- a/src/app/modules/info/pages/startups/startups.page.spec.ts
+++ b/src/app/modules/info/pages/startups/startups.page.spec.ts
@@ -2,6 +2,7 @@ import {ComponentFixture, TestBed, waitForAsync} from "@angular/core/testing";
 import {IonicModule} from "@ionic/angular";
 import {RouterTestingModule} from "@angular/router/testing";
 import {SharedModule} from "../../../../shared/shared.module";
+import {provideMockStore} from "@ngrx/store/testing";
 import {StartupsPage} from "./startups.page";
 
 describe("StartupsPage", () => {
@@ -12,6 +13,14 @@ describe("StartupsPage", () => {
     TestBed.configureTestingModule({
       declarations: [StartupsPage],
       imports: [IonicModule.forRoot(), RouterTestingModule, SharedModule],
+      providers: [
+        provideMockStore({
+          initialState: {
+            auth: {user: null, loading: false, error: null},
+            projects: {entities: {}, loading: false, error: null},
+          },
+        }),
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(StartupsPage);

--- a/src/app/modules/info/pages/team/team.page.spec.ts
+++ b/src/app/modules/info/pages/team/team.page.spec.ts
@@ -2,6 +2,7 @@ import {ComponentFixture, TestBed, waitForAsync} from "@angular/core/testing";
 import {IonicModule} from "@ionic/angular";
 import {RouterTestingModule} from "@angular/router/testing";
 import {SharedModule} from "../../../../shared/shared.module";
+import {provideMockStore} from "@ngrx/store/testing";
 import {TeamPage} from "./team.page";
 
 describe("TeamPage", () => {
@@ -12,6 +13,14 @@ describe("TeamPage", () => {
     TestBed.configureTestingModule({
       declarations: [TeamPage],
       imports: [IonicModule.forRoot(), RouterTestingModule, SharedModule],
+      providers: [
+        provideMockStore({
+          initialState: {
+            auth: {user: null, loading: false, error: null},
+            projects: {entities: {}, loading: false, error: null},
+          },
+        }),
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TeamPage);

--- a/src/app/modules/info/pages/think-tank/think-tank.page.spec.ts
+++ b/src/app/modules/info/pages/think-tank/think-tank.page.spec.ts
@@ -2,6 +2,7 @@ import {ComponentFixture, TestBed, waitForAsync} from "@angular/core/testing";
 import {IonicModule} from "@ionic/angular";
 import {RouterTestingModule} from "@angular/router/testing";
 import {SharedModule} from "../../../../shared/shared.module";
+import {provideMockStore} from "@ngrx/store/testing";
 import {ThinkTankPage} from "./think-tank.page";
 
 describe("ThinkTankPage", () => {
@@ -12,6 +13,14 @@ describe("ThinkTankPage", () => {
     TestBed.configureTestingModule({
       declarations: [ThinkTankPage],
       imports: [IonicModule.forRoot(), RouterTestingModule, SharedModule],
+      providers: [
+        provideMockStore({
+          initialState: {
+            auth: {user: null, loading: false, error: null},
+            projects: {entities: {}, loading: false, error: null},
+          },
+        }),
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ThinkTankPage);


### PR DESCRIPTION
## Summary
- ensure info page specs provide a mock store so SharedModule components work in isolation

## Testing
- `npx ng test --watch=false --browsers=ChromiumHeadless` *(fails: Chromium snap required)*

------
https://chatgpt.com/codex/tasks/task_e_688315c219808326938857cfd7b13639