### PR TITLE
Fix time tracking entries typing

### DIFF
--- a/src/app/modules/time-tracking/components/week-view/week-view.component.html
+++ b/src/app/modules/time-tracking/components/week-view/week-view.component.html
@@ -25,7 +25,7 @@
           </select>
         </ng-container>
         <ng-template #single>
-          {{ availableProjects[0]?.name }}
+          {{ availableProjects.length > 0 ? availableProjects[0].name : '' }}
         </ng-template>
         <button (click)="removeRow(i)">Remove</button>
       </td>

--- a/src/app/state/effects/time-tracking.effects.ts
+++ b/src/app/state/effects/time-tracking.effects.ts
@@ -31,6 +31,7 @@ import {
 } from "rxjs/operators";
 import {of, from} from "rxjs";
 import {AngularFirestore} from "@angular/fire/compat/firestore";
+import {TimeEntry} from "@shared/models/time-entry.model";
 import {TimeTrackingService} from "../../core/services/time-tracking.service";
 import * as TimeTrackingActions from "../actions/time-tracking.actions";
 import {ErrorHandlerService} from "../../core/services/error-handler.service";
@@ -122,7 +123,7 @@ export class TimeTrackingEffects {
         const end = new Date(start);
         end.setDate(start.getDate() + 7);
         return this.afs
-          .collection(`accounts/${accountId}/timeEntries`, (ref) =>
+          .collection<TimeEntry>(`accounts/${accountId}/timeEntries`, (ref) =>
             ref
               .where("userId", "==", userId)
               .where("date", ">=", start)
@@ -139,6 +140,7 @@ export class TimeTrackingEffects {
               TimeTrackingActions.loadTimeEntriesSuccess({
                 accountId,
                 userId,
+                weekStart,
                 entries,
               }),
             ),


### PR DESCRIPTION
## Summary
- ensure week-view template handles single project safely
- type valueChanges result as `TimeEntry` and include `weekStart` when loading entries

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6883b8814d708326a3e0e4817ef58116