### PR TITLE
feat(approvals): add weekly table view

### DIFF
--- a/src/app/modules/time-tracking/pages/approvals/approvals.page.html
+++ b/src/app/modules/time-tracking/pages/approvals/approvals.page.html
@@ -197,53 +197,37 @@
       </ng-container>
 
       <!-- By Project View -->
-      <ng-container
-        *ngIf="viewMode === 'by-project' && (projectGroupedEntries$ | async) as projectGroups"
-      >
+      <ng-container *ngIf="viewMode === 'by-project'">
         <div class="section-header">
           <h2>
             <ion-icon name="folder-outline"></ion-icon>
             Timesheets by Project
           </h2>
-          <p *ngIf="projectGroups.length === 0" class="no-entries">
+          <p *ngIf="(projectWeekRows$ | async)?.length === 0" class="no-entries">
             No project timesheets for this period
           </p>
         </div>
 
-        <ion-list *ngIf="projectGroups.length > 0">
-          <ion-item-group *ngFor="let project of projectGroups">
-            <ion-item-divider>
-              <ion-label>
-                <h3>{{ project.projectName }}</h3>
-                <p>Total: {{ project.totalHours }}h</p>
-              </ion-label>
-            </ion-item-divider>
-
-            <div *ngFor="let user of project.users">
-              <ion-item class="timesheet-item">
-                <ion-icon
-                  [name]="getStatusIcon(user.status)"
-                  [color]="getStatusColor(user.status)"
-                  slot="start"
-                >
-                </ion-icon>
-
-                <ion-label>
-                  <h2>{{ user.userName }}</h2>
-                  <h3>Hours: {{ user.totalHours }}</h3>
-                  <p>{{ user.entries.length }} time entries</p>
-                  <div class="status-badge">
-                    <ion-badge [color]="getStatusColor(user.status)">
-                      {{ user.status | titlecase }}
-                    </ion-badge>
-                  </div>
-                </ion-label>
-
-                <!-- Project-specific user actions would go here -->
-              </ion-item>
-            </div>
-          </ion-item-group>
-        </ion-list>
+        <div *ngIf="(projectWeekRows$ | async) as projectRows">
+          <table class="approvals-table">
+            <thead>
+              <tr>
+                <th>Project</th>
+                <th>Week Date (MM/DD/YY-MM/DD/YY)</th>
+                <th *ngFor="let day of ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday']">
+                  {{ day }}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr *ngFor="let row of projectRows">
+                <td>{{ row.projectName }}</td>
+                <td>{{ formatWeekRange(row.weekStart) }}</td>
+                <td *ngFor="let h of row.dailyHours">{{ h || 0 }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </ng-container>
 
       <!-- All View (Combined) -->

--- a/src/app/modules/time-tracking/pages/approvals/approvals.page.scss
+++ b/src/app/modules/time-tracking/pages/approvals/approvals.page.scss
@@ -139,6 +139,29 @@
   }
 }
 
+.approvals-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 16px;
+
+  th,
+  td {
+    border: 1px solid var(--ion-color-light-shade);
+    padding: 8px;
+    text-align: center;
+  }
+
+  th {
+    background: var(--ion-color-light);
+    font-weight: 600;
+  }
+
+  td:first-child,
+  td:nth-child(2) {
+    text-align: left;
+  }
+}
+
 .timesheet-item {
   --padding-start: 16px;
   --padding-end: 16px;


### PR DESCRIPTION
## Summary
- show weekly hours per project in a table with day columns
- support aggregating entries by project and week for approvals

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68a2849bfe7c8326a28fadb3a445a280