### PR TITLE
feat: add administrative role templates

### DIFF
--- a/docs/ROLES_HIERARCHY_SYSTEM.md
+++ b/docs/ROLES_HIERARCHY_SYSTEM.md
@@ -100,10 +100,12 @@ The system defines 10 standardized categories, each designed for specific relati
 - **Key Roles**: Corporate Sponsor, Vendor, Client Organization, Board Member Organization
 - **Hierarchy**: Board Members/Sponsors → Vendors/Clients
 
-### 10. **Administrative** _(Reserved for future use)_
+### 10. **Administrative**
 
 - **Purpose**: System and administrative functions
 - **Use Cases**: Platform administration, system roles
+- **Key Roles**: Super Admin, System Administrator, Support Agent, Auditor
+- **Hierarchy**: Super Admin → System Administrator → Support Agent, Auditor
 
 ## Standard Role Templates
 

--- a/docs/ROLES_QUICK_REFERENCE.md
+++ b/docs/ROLES_QUICK_REFERENCE.md
@@ -105,6 +105,14 @@ Category: Organization
 └── Member (Standalone)
 ```
 
+```
+Category: Administrative
+├── Super Admin
+│   └── System Administrator
+│       ├── Support Agent
+│       └── Auditor
+```
+
 ### Pattern 2: Multi-Category Assignment
 
 ```typescript

--- a/docs/ROLES_TECHNICAL_IMPLEMENTATION.md
+++ b/docs/ROLES_TECHNICAL_IMPLEMENTATION.md
@@ -52,6 +52,10 @@ export interface StandardRoleHierarchy {
 }
 ```
 
+The Administrative category is now active, providing templates for Super Admin,
+System Administrator, Support Agent, and Auditor to support platform-level
+operations.
+
 **Key Features**:
 
 - **Category Enum**: Strongly typed categories prevent invalid assignments

--- a/shared/models/standard-role-template.model.ts
+++ b/shared/models/standard-role-template.model.ts
@@ -236,6 +236,62 @@ export const STANDARD_ROLE_TEMPLATES: StandardRoleTemplate[] = [
     suggestedChildRoles: [],
   },
 
+  // Administrative Category
+  {
+    id: "std_super_admin",
+    category: "Administrative",
+    name: "Super Admin",
+    description:
+      "Highest-level platform administrator with full system control",
+    defaultPermissions: [
+      "manage_platform",
+      "manage_system_settings",
+      "manage_roles",
+      "view_audit_logs",
+    ],
+    applicableGroupTypes: ["Platform"],
+    icon: "planet",
+    isSystemRole: true,
+    suggestedChildRoles: ["System Administrator"],
+  },
+  {
+    id: "std_system_admin",
+    category: "Administrative",
+    name: "System Administrator",
+    description: "Manages system configuration and user administration",
+    defaultPermissions: [
+      "manage_system_settings",
+      "manage_users",
+      "view_audit_logs",
+    ],
+    applicableGroupTypes: ["Platform"],
+    icon: "settings",
+    isSystemRole: true,
+    suggestedChildRoles: ["Support Agent", "Auditor"],
+  },
+  {
+    id: "std_support_agent",
+    category: "Administrative",
+    name: "Support Agent",
+    description: "Provides user support and resolves tickets",
+    defaultPermissions: ["support_users", "resolve_tickets"],
+    applicableGroupTypes: ["Platform"],
+    icon: "help-buoy",
+    isSystemRole: true,
+    suggestedChildRoles: [],
+  },
+  {
+    id: "std_auditor",
+    category: "Administrative",
+    name: "Auditor",
+    description: "Reviews system activity and ensures compliance",
+    defaultPermissions: ["view_audit_logs", "view_reports"],
+    applicableGroupTypes: ["Platform"],
+    icon: "search",
+    isSystemRole: true,
+    suggestedChildRoles: [],
+  },
+
   // Partnership Category
   {
     id: "std_strategic_partner",
@@ -403,6 +459,21 @@ export const STANDARD_ROLE_HIERARCHIES: StandardRoleHierarchy[] = [
       (r) => r.category === "Community" && r.name === "Resident",
     ),
     description: "Community structure with leaders guiding residents",
+  },
+  {
+    category: "Administrative",
+    parentRoles: STANDARD_ROLE_TEMPLATES.filter(
+      (r) =>
+        r.category === "Administrative" &&
+        ["Super Admin", "System Administrator"].includes(r.name),
+    ),
+    childRoleTemplates: STANDARD_ROLE_TEMPLATES.filter(
+      (r) =>
+        r.category === "Administrative" &&
+        ["Support Agent", "Auditor"].includes(r.name),
+    ),
+    description:
+      "Platform oversight with super admins managing system administrators who oversee support agents and auditors",
   },
   {
     category: "Partnership",


### PR DESCRIPTION
## Summary
- add Super Admin, System Administrator, Support Agent, and Auditor templates under Administrative category
- define Administrative hierarchy and document role chain
- update role docs to activate Administrative category

## Testing
- `CHROME_BIN=chromium-browser npm test` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*
- `npm --prefix functions test` *(fails: firebase: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a28911e9848326ae3983980a544bcb