### PR TITLE
feat: expand corporate role templates

### DIFF
--- a/docs/ROLES_HIERARCHY_SYSTEM.md
+++ b/docs/ROLES_HIERARCHY_SYSTEM.md
@@ -96,9 +96,9 @@ The system defines 10 standardized categories, each designed for specific relati
 ### 9. **Corporate**
 
 - **Purpose**: Corporate relationships and business partnerships
-- **Use Cases**: Sponsorships, vendor relationships, client management
-- **Key Roles**: Corporate Sponsor, Vendor, Client Organization, Board Member Organization
-- **Hierarchy**: Board Members/Sponsors → Vendors/Clients
+- **Use Cases**: Sponsorships, investor relations, channel partnerships, vendor and contractor management, client management
+- **Key Roles**: Corporate Sponsor, Board Member Organization, Investor Organization, Channel Partner Organization, Vendor, Supplier Organization, Contractor Organization, Client Organization
+- **Hierarchy**: Board Member Org/Corporate Sponsor → Investor/Channel Partner → Vendor/Supplier/Contractor/Client Orgs
 
 ### 10. **Administrative** _(Reserved for future use)_
 
@@ -148,9 +148,13 @@ interface StandardRoleTemplate {
 #### Corporate Category
 
 - **Corporate Sponsor**: Corporate entity providing sponsorship support
-- **Vendor**: Supplier or vendor organization
-- **Client Organization**: Client or customer organization
 - **Board Member Organization**: Organization with board representation
+- **Investor Organization**: Organization providing investment or funding
+- **Channel Partner Organization**: Organization participating in channel partnerships
+- **Vendor**: Supplier or vendor organization
+- **Supplier Organization**: Organization supplying goods or materials
+- **Contractor Organization**: Organization providing contract-based services
+- **Client Organization**: Client or customer organization
 
 ## Role Assignment Models
 

--- a/shared/models/standard-role-template.model.ts
+++ b/shared/models/standard-role-template.model.ts
@@ -299,28 +299,6 @@ export const STANDARD_ROLE_TEMPLATES: StandardRoleTemplate[] = [
     suggestedChildRoles: ["Platinum Sponsor", "Gold Sponsor", "Silver Sponsor"],
   },
   {
-    id: "std_vendor",
-    category: "Corporate",
-    name: "Vendor",
-    description: "Supplier or vendor organization",
-    defaultPermissions: ["vendor_portal", "contract_management"],
-    applicableGroupTypes: ["group", "organization"],
-    icon: "storefront",
-    isSystemRole: true,
-    suggestedChildRoles: [],
-  },
-  {
-    id: "std_client_organization",
-    category: "Corporate",
-    name: "Client Organization",
-    description: "Client or customer organization",
-    defaultPermissions: ["client_portal", "service_access", "support_tickets"],
-    applicableGroupTypes: ["group", "organization"],
-    icon: "briefcase",
-    isSystemRole: true,
-    suggestedChildRoles: [],
-  },
-  {
     id: "std_board_member_org",
     category: "Corporate",
     name: "Board Member Organization",
@@ -332,6 +310,72 @@ export const STANDARD_ROLE_TEMPLATES: StandardRoleTemplate[] = [
     ],
     applicableGroupTypes: ["group", "organization"],
     icon: "shield-checkmark",
+    isSystemRole: true,
+    suggestedChildRoles: [],
+  },
+  {
+    id: "std_investor_org",
+    category: "Corporate",
+    name: "Investor Organization",
+    description: "Organization providing investment or funding",
+    defaultPermissions: ["investor_portal", "financial_reports"],
+    applicableGroupTypes: ["group", "organization"],
+    icon: "trending-up",
+    isSystemRole: true,
+    suggestedChildRoles: [],
+  },
+  {
+    id: "std_channel_partner_org",
+    category: "Corporate",
+    name: "Channel Partner Organization",
+    description: "Organization participating in channel partnerships",
+    defaultPermissions: ["channel_portal", "co_marketing", "sales_support"],
+    applicableGroupTypes: ["group", "organization"],
+    icon: "swap-horizontal",
+    isSystemRole: true,
+    suggestedChildRoles: [],
+  },
+  {
+    id: "std_vendor",
+    category: "Corporate",
+    name: "Vendor",
+    description: "Supplier or vendor organization",
+    defaultPermissions: ["vendor_portal", "contract_management"],
+    applicableGroupTypes: ["group", "organization"],
+    icon: "storefront",
+    isSystemRole: true,
+    suggestedChildRoles: [],
+  },
+  {
+    id: "std_supplier_org",
+    category: "Corporate",
+    name: "Supplier Organization",
+    description: "Organization supplying goods or materials",
+    defaultPermissions: ["supply_portal", "inventory_access"],
+    applicableGroupTypes: ["group", "organization"],
+    icon: "cube",
+    isSystemRole: true,
+    suggestedChildRoles: [],
+  },
+  {
+    id: "std_contractor_org",
+    category: "Corporate",
+    name: "Contractor Organization",
+    description: "Organization providing contract-based services",
+    defaultPermissions: ["contractor_portal", "service_orders"],
+    applicableGroupTypes: ["group", "organization"],
+    icon: "construct",
+    isSystemRole: true,
+    suggestedChildRoles: [],
+  },
+  {
+    id: "std_client_organization",
+    category: "Corporate",
+    name: "Client Organization",
+    description: "Client or customer organization",
+    defaultPermissions: ["client_portal", "service_access", "support_tickets"],
+    applicableGroupTypes: ["group", "organization"],
+    icon: "briefcase",
     isSystemRole: true,
     suggestedChildRoles: [],
   },
@@ -431,9 +475,33 @@ export const STANDARD_ROLE_HIERARCHIES: StandardRoleHierarchy[] = [
     childRoleTemplates: STANDARD_ROLE_TEMPLATES.filter(
       (r) =>
         r.category === "Corporate" &&
-        ["Vendor", "Client Organization"].includes(r.name),
+        ["Investor Organization", "Channel Partner Organization"].includes(
+          r.name,
+        ),
     ),
     description:
-      "Corporate relationships with sponsors and board members having elevated access",
+      "Sponsors and board member organizations overseeing investors and channel partners",
+  },
+  {
+    category: "Corporate",
+    parentRoles: STANDARD_ROLE_TEMPLATES.filter(
+      (r) =>
+        r.category === "Corporate" &&
+        ["Investor Organization", "Channel Partner Organization"].includes(
+          r.name,
+        ),
+    ),
+    childRoleTemplates: STANDARD_ROLE_TEMPLATES.filter(
+      (r) =>
+        r.category === "Corporate" &&
+        [
+          "Vendor",
+          "Supplier Organization",
+          "Contractor Organization",
+          "Client Organization",
+        ].includes(r.name),
+    ),
+    description:
+      "Investor and channel partner relationships managing vendors, suppliers, contractors, and clients",
   },
 ];


### PR DESCRIPTION
## Summary
- add investor, supplier, channel partner, and contractor organization templates
- model multi-tier corporate relationships
- document expanded corporate role hierarchy

## Testing
- `npm run lint` *(fails: lint errors in unrelated files)*
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68a2891076a48326b754e5643ae50990