### PR TITLE
feat: add community role templates and hierarchy

### DIFF
--- a/docs/ROLES_HIERARCHY_SYSTEM.md
+++ b/docs/ROLES_HIERARCHY_SYSTEM.md
@@ -83,8 +83,8 @@ The system defines 10 standardized categories, each designed for specific relati
 
 - **Purpose**: Community organization and civic engagement
 - **Use Cases**: Neighborhood groups, civic organizations
-- **Key Roles**: Community Leader, Resident
-- **Hierarchy**: Leader → Residents
+- **Key Roles**: Community Leader, Event Organizer, Outreach Coordinator, Community Volunteer, Sponsor
+- **Hierarchy**: Community Leader → Event Organizer/Outreach Coordinator → Community Volunteer; Sponsor (standalone)
 
 ### 8. **Partnership**
 

--- a/docs/ROLES_QUICK_REFERENCE.md
+++ b/docs/ROLES_QUICK_REFERENCE.md
@@ -105,6 +105,16 @@ Category: Organization
 └── Member (Standalone)
 ```
 
+### Community Roles Overview
+
+- **Community Leader** – Guides initiatives and delegates to organizers.
+- **Event Organizer** – Plans and manages community events.
+- **Outreach Coordinator** – Drives outreach and communication efforts.
+- **Community Volunteer** – Supports events and outreach activities.
+- **Sponsor** – Provides funding or resources (standalone).
+
+Hierarchy: Community Leader → Event Organizer/Outreach Coordinator → Community Volunteer; Sponsor (standalone)
+
 ### Pattern 2: Multi-Category Assignment
 
 ```typescript

--- a/shared/models/standard-role-template.model.ts
+++ b/shared/models/standard-role-template.model.ts
@@ -225,6 +225,50 @@ export const STANDARD_ROLE_TEMPLATES: StandardRoleTemplate[] = [
     suggestedChildRoles: ["Event Organizer", "Outreach Coordinator"],
   },
   {
+    id: "std_event_organizer",
+    category: "Community",
+    name: "Event Organizer",
+    description: "Plans and manages community events",
+    defaultPermissions: ["organize_events", "manage_event_participation"],
+    applicableGroupTypes: ["Community", "Nonprofit"],
+    icon: "calendar",
+    isSystemRole: true,
+    suggestedChildRoles: ["Community Volunteer"],
+  },
+  {
+    id: "std_outreach_coordinator",
+    category: "Community",
+    name: "Outreach Coordinator",
+    description: "Coordinates community outreach and engagement",
+    defaultPermissions: ["manage_outreach", "communicate_with_members"],
+    applicableGroupTypes: ["Community", "Nonprofit"],
+    icon: "share-social",
+    isSystemRole: true,
+    suggestedChildRoles: ["Community Volunteer"],
+  },
+  {
+    id: "std_community_volunteer",
+    category: "Community",
+    name: "Community Volunteer",
+    description: "Supports events and outreach efforts",
+    defaultPermissions: ["assist_events", "participate_in_outreach"],
+    applicableGroupTypes: ["Community", "Nonprofit"],
+    icon: "hand-left",
+    isSystemRole: true,
+    suggestedChildRoles: [],
+  },
+  {
+    id: "std_sponsor",
+    category: "Community",
+    name: "Sponsor",
+    description: "Provides funding or resources for community initiatives",
+    defaultPermissions: ["contribute_resources"],
+    applicableGroupTypes: ["Community", "Nonprofit"],
+    icon: "cash",
+    isSystemRole: true,
+    suggestedChildRoles: [],
+  },
+  {
     id: "std_resident",
     category: "Community",
     name: "Resident",
@@ -400,9 +444,24 @@ export const STANDARD_ROLE_HIERARCHIES: StandardRoleHierarchy[] = [
       (r) => r.category === "Community" && r.name === "Community Leader",
     ),
     childRoleTemplates: STANDARD_ROLE_TEMPLATES.filter(
-      (r) => r.category === "Community" && r.name === "Resident",
+      (r) =>
+        r.category === "Community" &&
+        ["Event Organizer", "Outreach Coordinator"].includes(r.name),
     ),
-    description: "Community structure with leaders guiding residents",
+    description:
+      "Community leaders delegate event organization and outreach coordination",
+  },
+  {
+    category: "Community",
+    parentRoles: STANDARD_ROLE_TEMPLATES.filter(
+      (r) =>
+        r.category === "Community" &&
+        ["Event Organizer", "Outreach Coordinator"].includes(r.name),
+    ),
+    childRoleTemplates: STANDARD_ROLE_TEMPLATES.filter(
+      (r) => r.category === "Community" && r.name === "Community Volunteer",
+    ),
+    description: "Organizers and coordinators manage community volunteers",
   },
   {
     category: "Partnership",


### PR DESCRIPTION
## Summary
- add Event Organizer, Outreach Coordinator, Sponsor, and Community Volunteer templates
- link Community Leader to organizers/coordinators and volunteers in STANDARD_ROLE_HIERARCHIES
- document community roles and responsibilities

## Testing
- `npm run lint` *(fails: Unexpected any and prettier errors)*
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68a288f75c54832696002db3d4dfab13