### PR TITLE
feat: expand collaboration role templates

### DIFF
--- a/docs/ROLES_HIERARCHY_SYSTEM.md
+++ b/docs/ROLES_HIERARCHY_SYSTEM.md
@@ -55,8 +55,8 @@ The system defines 10 standardized categories, each designed for specific relati
 
 - **Purpose**: Project-based teamwork
 - **Use Cases**: Cross-functional projects, collaborative initiatives
-- **Key Roles**: Project Lead, Collaborator
-- **Hierarchy**: Lead → Collaborators
+- **Key Roles**: Project Lead, Subject Matter Expert, Reviewer, Stakeholder, Collaborator, Observer
+- **Hierarchy**: Project Lead → Subject Matter Expert/Reviewer → Collaborator/Observer
 
 ### 4. **Family**
 
@@ -138,6 +138,15 @@ interface StandardRoleTemplate {
 - **Volunteer Coordinator**: Manages volunteer programs and activities
 - **Volunteer**: Individual contributing time and skills
 
+#### Collaboration Category
+
+- **Project Lead**: Leads specific projects and initiatives
+- **Subject Matter Expert**: Provides specialized knowledge for project tasks
+- **Reviewer**: Ensures quality through review and approval
+- **Stakeholder**: Offers requirements and strategic feedback
+- **Collaborator**: Contributes to project execution and shared resources
+- **Observer**: Monitors progress without direct contribution
+
 #### Partnership Category
 
 - **Strategic Partner**: Key strategic alliance partner organization
@@ -201,6 +210,19 @@ Administrator
     ├── Content Reviewer
     └── Community Manager
 Member (base level)
+```
+
+#### Collaboration Hierarchy
+
+```
+Project Lead
+├── Subject Matter Expert
+│   ├── Collaborator
+│   └── Observer
+├── Reviewer
+│   ├── Collaborator
+│   └── Observer
+└── Stakeholder
 ```
 
 #### Volunteer Hierarchy

--- a/shared/models/standard-role-template.model.ts
+++ b/shared/models/standard-role-template.model.ts
@@ -126,7 +126,46 @@ export const STANDARD_ROLE_TEMPLATES: StandardRoleTemplate[] = [
     applicableGroupTypes: ["Nonprofit", "Business", "Community"],
     icon: "flag",
     isSystemRole: true,
-    suggestedChildRoles: ["Project Member", "Subject Matter Expert"],
+    suggestedChildRoles: [
+      "Subject Matter Expert",
+      "Reviewer",
+      "Stakeholder",
+      "Collaborator",
+      "Observer",
+    ],
+  },
+  {
+    id: "std_subject_matter_expert",
+    category: "Collaboration",
+    name: "Subject Matter Expert",
+    description: "Provides specialized knowledge for project tasks",
+    defaultPermissions: ["provide_expertise", "support_decisions"],
+    applicableGroupTypes: ["Nonprofit", "Business", "Community"],
+    icon: "school",
+    isSystemRole: true,
+    suggestedChildRoles: ["Collaborator"],
+  },
+  {
+    id: "std_reviewer",
+    category: "Collaboration",
+    name: "Reviewer",
+    description: "Reviews work products and ensures quality standards",
+    defaultPermissions: ["review_work", "approve_changes"],
+    applicableGroupTypes: ["Nonprofit", "Business", "Community"],
+    icon: "checkmark-done",
+    isSystemRole: true,
+    suggestedChildRoles: ["Collaborator"],
+  },
+  {
+    id: "std_stakeholder",
+    category: "Collaboration",
+    name: "Stakeholder",
+    description: "Provides project requirements and strategic feedback",
+    defaultPermissions: ["view_project_status", "provide_feedback"],
+    applicableGroupTypes: ["Nonprofit", "Business", "Community"],
+    icon: "briefcase",
+    isSystemRole: true,
+    suggestedChildRoles: ["Observer"],
   },
   {
     id: "std_collaborator",
@@ -136,6 +175,17 @@ export const STANDARD_ROLE_TEMPLATES: StandardRoleTemplate[] = [
     defaultPermissions: ["contribute_to_projects", "share_resources"],
     applicableGroupTypes: ["Nonprofit", "Business", "Community"],
     icon: "git-merge",
+    isSystemRole: true,
+    suggestedChildRoles: [],
+  },
+  {
+    id: "std_observer",
+    category: "Collaboration",
+    name: "Observer",
+    description: "Monitors project progress without direct contribution",
+    defaultPermissions: ["view_project_updates"],
+    applicableGroupTypes: ["Nonprofit", "Business", "Community"],
+    icon: "eye",
     isSystemRole: true,
     suggestedChildRoles: [],
   },
@@ -368,10 +418,26 @@ export const STANDARD_ROLE_HIERARCHIES: StandardRoleHierarchy[] = [
       (r) => r.category === "Collaboration" && r.name === "Project Lead",
     ),
     childRoleTemplates: STANDARD_ROLE_TEMPLATES.filter(
-      (r) => r.category === "Collaboration" && r.name === "Collaborator",
+      (r) =>
+        r.category === "Collaboration" &&
+        ["Subject Matter Expert", "Reviewer"].includes(r.name),
     ),
     description:
-      "Project-based collaboration with leads managing collaborators",
+      "Project leads coordinate SMEs and reviewers in multi-tier collaborations",
+  },
+  {
+    category: "Collaboration",
+    parentRoles: STANDARD_ROLE_TEMPLATES.filter(
+      (r) =>
+        r.category === "Collaboration" &&
+        ["Subject Matter Expert", "Reviewer"].includes(r.name),
+    ),
+    childRoleTemplates: STANDARD_ROLE_TEMPLATES.filter(
+      (r) =>
+        r.category === "Collaboration" &&
+        ["Collaborator", "Observer"].includes(r.name),
+    ),
+    description: "SMEs and reviewers oversee collaborators and observers",
   },
   {
     category: "Family",


### PR DESCRIPTION
## Summary
- add Subject Matter Expert, Reviewer, Stakeholder, and Observer collaboration templates
- model multi-tier collaboration hierarchy
- document collaboration sub-roles and responsibilities

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a288d0eb688326ac55fb1a20e507c6