### PR TITLE
feat: add organization role hierarchy

### DIFF
--- a/docs/ROLES_HIERARCHY_SYSTEM.md
+++ b/docs/ROLES_HIERARCHY_SYSTEM.md
@@ -41,8 +41,8 @@ The system defines 10 standardized categories, each designed for specific relati
 
 - **Purpose**: Traditional organizational structures
 - **Use Cases**: Nonprofits, businesses, government agencies
-- **Key Roles**: Administrator, Moderator, Member
-- **Hierarchy**: Admin → Moderator → Member
+- **Key Roles**: Administrator, Moderator, Project Manager, Department Head, Team Lead, Staff, Intern, Member
+- **Hierarchy**: Administrator → Moderator → Project Manager/Department Head → Team Lead → Staff/Intern → Member
 
 ### 2. **Volunteer**
 
@@ -131,6 +131,11 @@ interface StandardRoleTemplate {
 
 - **Administrator**: Full system access and management capabilities
 - **Moderator**: Content moderation and member management
+- **Project Manager**: Oversees projects and coordinates team activities
+- **Department Head**: Manages a specific department within the organization
+- **Team Lead**: Leads a team and coordinates staff members
+- **Staff**: Staff member with general responsibilities
+- **Intern**: Intern with limited access for learning purposes
 - **Member**: Standard organization member with basic access
 
 #### Volunteer Category
@@ -194,13 +199,16 @@ interface RelatedAccount {
 
 ```
 Administrator
-├── Department Head
-│   ├── Team Lead
-│   └── Senior Specialist
-└── Moderator
-    ├── Content Reviewer
-    └── Community Manager
-Member (base level)
+├── Moderator
+│   └── Member
+├── Project Manager
+│   └── Team Lead
+│       ├── Staff
+│       └── Intern
+└── Department Head
+    └── Team Lead
+        ├── Staff
+        └── Intern
 ```
 
 #### Volunteer Hierarchy
@@ -336,7 +344,15 @@ The system uses NgRx for state management with the following selectors:
 Organization Category:
 - Administrator (Executive Director)
   - Moderator (Program Manager)
-    - Member (Staff/Volunteers)
+    - Member
+  - Department Head
+    - Team Lead
+      - Staff
+      - Intern
+  - Project Manager
+    - Team Lead
+      - Staff
+      - Intern
 
 Volunteer Category:
 - Volunteer Coordinator

--- a/docs/ROLES_QUICK_REFERENCE.md
+++ b/docs/ROLES_QUICK_REFERENCE.md
@@ -97,12 +97,27 @@ getRolesForAccount(account: RelatedAccount): GroupRole[] {
 
 ### Pattern 1: Hierarchical Role Structure
 
+Standard organization roles now include:
+
+- **Project Manager** – Oversees projects and coordinates team activities
+- **Department Head** – Manages a department within the organization
+- **Team Lead** – Leads a team and coordinates staff
+- **Staff** – Staff member with general responsibilities
+- **Intern** – Intern with limited access for learning purposes
+
 ```
 Category: Organization
 ├── Administrator (Parent)
+│   ├── Project Manager (Child)
+│   │   └── Team Lead
+│   │       ├── Staff
+│   │       └── Intern
 │   ├── Department Head (Child)
-│   └── Project Manager (Child)
-└── Member (Standalone)
+│   │   └── Team Lead
+│   │       ├── Staff
+│   │       └── Intern
+│   └── Moderator (Child)
+│       └── Member
 ```
 
 ### Pattern 2: Multi-Category Assignment

--- a/docs/ROLES_TECHNICAL_IMPLEMENTATION.md
+++ b/docs/ROLES_TECHNICAL_IMPLEMENTATION.md
@@ -59,6 +59,30 @@ export interface StandardRoleHierarchy {
 - **Suggested Hierarchies**: Pre-defined child role recommendations
 - **Group Type Filtering**: Roles can be restricted to specific group types
 
+### Organization Role Hierarchy
+
+The following standard organization roles extend the platform's default templates:
+
+- **Project Manager**: Oversees projects and coordinates team activities
+- **Department Head**: Manages a specific department within the organization
+- **Team Lead**: Leads a team and coordinates staff members
+- **Staff**: Staff member with general responsibilities
+- **Intern**: Intern with limited access for learning purposes
+
+```
+Administrator
+├── Moderator
+│   └── Member
+├── Project Manager
+│   └── Team Lead
+│       ├── Staff
+│       └── Intern
+└── Department Head
+    └── Team Lead
+        ├── Staff
+        └── Intern
+```
+
 ### GroupRole Model
 
 **Location**: `/shared/models/group-role.model.ts`
@@ -668,14 +692,14 @@ describe("Role Management Page", () => {
     const categories = await page
       .locator(".category-header h3")
       .allTextContents();
-    expect(categories).toContain("Organization (3)");
+    expect(categories).toContain("Organization (8)");
     expect(categories).toContain("Volunteer (2)");
 
     // Verify role display within categories
     const orgRoles = await page
       .locator('[data-category="Organization"] .role-row')
       .count();
-    expect(orgRoles).toBe(3);
+    expect(orgRoles).toBe(8);
   });
 
   it("should enforce parent role category restrictions", async () => {

--- a/shared/models/standard-role-template.model.ts
+++ b/shared/models/standard-role-template.model.ts
@@ -67,7 +67,13 @@ export const STANDARD_ROLE_TEMPLATES: StandardRoleTemplate[] = [
     applicableGroupTypes: ["Nonprofit", "Business", "Community", "Government"],
     icon: "shield-checkmark",
     isSystemRole: true,
-    suggestedChildRoles: ["Project Manager", "Department Head"],
+    suggestedChildRoles: [
+      "Project Manager",
+      "Department Head",
+      "Team Lead",
+      "Staff",
+      "Intern",
+    ],
   },
   {
     id: "std_moderator",
@@ -78,7 +84,13 @@ export const STANDARD_ROLE_TEMPLATES: StandardRoleTemplate[] = [
     applicableGroupTypes: ["Nonprofit", "Business", "Community"],
     icon: "hammer",
     isSystemRole: true,
-    suggestedChildRoles: ["Content Reviewer", "Community Manager"],
+    suggestedChildRoles: [
+      "Content Reviewer",
+      "Community Manager",
+      "Team Lead",
+      "Staff",
+      "Intern",
+    ],
   },
   {
     id: "std_member",
@@ -88,6 +100,62 @@ export const STANDARD_ROLE_TEMPLATES: StandardRoleTemplate[] = [
     defaultPermissions: ["view_content", "participate"],
     applicableGroupTypes: ["Nonprofit", "Business", "Community", "Government"],
     icon: "person",
+    isSystemRole: true,
+    suggestedChildRoles: [],
+  },
+
+  {
+    id: "std_project_manager",
+    category: "Organization",
+    name: "Project Manager",
+    description: "Oversees projects and coordinates team activities",
+    defaultPermissions: ["manage_projects", "assign_tasks"],
+    applicableGroupTypes: ["Nonprofit", "Business", "Community", "Government"],
+    icon: "clipboard",
+    isSystemRole: true,
+    suggestedChildRoles: ["Team Lead", "Staff", "Intern"],
+  },
+  {
+    id: "std_department_head_org",
+    category: "Organization",
+    name: "Department Head",
+    description: "Manages a specific department within the organization",
+    defaultPermissions: ["manage_department", "approve_requests"],
+    applicableGroupTypes: ["Nonprofit", "Business", "Community", "Government"],
+    icon: "briefcase",
+    isSystemRole: true,
+    suggestedChildRoles: ["Team Lead"],
+  },
+  {
+    id: "std_team_lead",
+    category: "Organization",
+    name: "Team Lead",
+    description: "Leads a team and coordinates staff members",
+    defaultPermissions: ["manage_team", "assign_tasks"],
+    applicableGroupTypes: ["Nonprofit", "Business", "Community", "Government"],
+    icon: "people-circle",
+    isSystemRole: true,
+    suggestedChildRoles: ["Staff", "Intern"],
+  },
+  {
+    id: "std_staff",
+    category: "Organization",
+    name: "Staff",
+    description: "Staff member with general responsibilities",
+    defaultPermissions: ["access_workplace_tools", "collaborate"],
+    applicableGroupTypes: ["Nonprofit", "Business", "Community", "Government"],
+    icon: "person-circle",
+    isSystemRole: true,
+    suggestedChildRoles: [],
+  },
+  {
+    id: "std_intern",
+    category: "Organization",
+    name: "Intern",
+    description: "Intern with limited access for learning purposes",
+    defaultPermissions: ["view_content", "participate_in_training"],
+    applicableGroupTypes: ["Nonprofit", "Business", "Community", "Government"],
+    icon: "school",
     isSystemRole: true,
     suggestedChildRoles: [],
   },
@@ -346,10 +414,43 @@ export const STANDARD_ROLE_HIERARCHIES: StandardRoleHierarchy[] = [
         ["Administrator", "Moderator"].includes(r.name),
     ),
     childRoleTemplates: STANDARD_ROLE_TEMPLATES.filter(
-      (r) => r.category === "Organization" && r.name === "Member",
+      (r) =>
+        r.category === "Organization" &&
+        [
+          "Project Manager",
+          "Department Head",
+          "Team Lead",
+          "Staff",
+          "Intern",
+          "Member",
+        ].includes(r.name),
     ),
     description:
-      "Basic organizational structure with administrators, moderators, and members",
+      "Organizational structure with administrators and moderators overseeing managers, team leads, staff, interns, and members",
+  },
+  {
+    category: "Organization",
+    parentRoles: STANDARD_ROLE_TEMPLATES.filter(
+      (r) =>
+        r.category === "Organization" &&
+        ["Project Manager", "Department Head"].includes(r.name),
+    ),
+    childRoleTemplates: STANDARD_ROLE_TEMPLATES.filter(
+      (r) => r.category === "Organization" && r.name === "Team Lead",
+    ),
+    description:
+      "Mid-level structure with project managers and department heads guiding team leads",
+  },
+  {
+    category: "Organization",
+    parentRoles: STANDARD_ROLE_TEMPLATES.filter(
+      (r) => r.category === "Organization" && r.name === "Team Lead",
+    ),
+    childRoleTemplates: STANDARD_ROLE_TEMPLATES.filter(
+      (r) =>
+        r.category === "Organization" && ["Staff", "Intern"].includes(r.name),
+    ),
+    description: "Team leads supervising staff and interns",
   },
   {
     category: "Volunteer",


### PR DESCRIPTION
## Summary
- add Project Manager, Department Head, Team Lead, Staff, and Intern templates under Organization category
- extend role hierarchies so admins and moderators parent new organization roles
- document new organization hierarchy and roles across reference and technical guides

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a28896d7088326ad495acd5f37f4dd