### PR TITLE
feat: collapsible role tables and hide selected templates

### DIFF
--- a/src/app/modules/account/components/standard-role-selector/standard-role-selector.component.html
+++ b/src/app/modules/account/components/standard-role-selector/standard-role-selector.component.html
@@ -56,8 +56,9 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
       <h5>Available {{ selectedCategory }} Roles</h5>
       <ion-list>
         <ion-item
-          *ngFor="let template of getTemplatesForCategory(selectedCategory)"
+          *ngFor="let template of getTemplatesForCategory(selectedCategory); trackBy: trackTemplate"
           button
+          [disabled]="isTemplateUsed(template)"
           (click)="selectTemplate(template)"
         >
           <ion-icon

--- a/src/app/modules/account/components/standard-role-selector/standard-role-selector.component.ts
+++ b/src/app/modules/account/components/standard-role-selector/standard-role-selector.component.ts
@@ -19,7 +19,15 @@
  *******************************************************************************/
 // src/app/modules/account/components/standard-role-selector/standard-role-selector.component.ts
 
-import {Component, EventEmitter, Input, Output, OnInit} from "@angular/core";
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  OnInit,
+  OnChanges,
+  SimpleChanges,
+} from "@angular/core";
 import {
   StandardRoleTemplate,
   StandardRoleCategory,
@@ -33,7 +41,7 @@ import {GroupRole} from "../../../../../../shared/models/group-role.model";
   templateUrl: "./standard-role-selector.component.html",
   styleUrls: ["./standard-role-selector.component.scss"],
 })
-export class StandardRoleSelectorComponent implements OnInit {
+export class StandardRoleSelectorComponent implements OnInit, OnChanges {
   @Input() groupType?: string;
   @Input() existingRoles: GroupRole[] = [];
   @Output() roleSelected = new EventEmitter<StandardRoleTemplate>();
@@ -58,6 +66,13 @@ export class StandardRoleSelectorComponent implements OnInit {
   ngOnInit() {
     this.loadAvailableTemplates();
     this.categorizeTemplates();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes["existingRoles"] || changes["groupType"]) {
+      this.loadAvailableTemplates();
+      this.categorizeTemplates();
+    }
   }
 
   private loadAvailableTemplates() {
@@ -95,6 +110,11 @@ export class StandardRoleSelectorComponent implements OnInit {
 
   selectTemplate(template: StandardRoleTemplate) {
     this.roleSelected.emit(template);
+    // Immediately remove the selected template so it cannot be chosen again
+    this.availableTemplates = this.availableTemplates.filter(
+      (t) => t.id !== template.id,
+    );
+    this.categorizeTemplates();
   }
 
   toggleCustomRoleForm() {

--- a/src/app/modules/account/pages/role-management/role-management.page.html
+++ b/src/app/modules/account/pages/role-management/role-management.page.html
@@ -15,11 +15,13 @@
           <!-- Category Header -->
           <div
             class="category-header"
+            (click)="toggleCategory(categoryGroup.category)"
             style="
               margin: 16px 0 8px 0;
               padding: 8px;
               background-color: var(--ion-color-light);
               border-radius: 8px;
+              cursor: pointer;
             "
           >
             <h3
@@ -27,152 +29,166 @@
                 margin: 0;
                 display: flex;
                 align-items: center;
+                justify-content: space-between;
                 gap: 8px;
                 color: var(--ion-color-dark);
               "
             >
+              <span style="display: flex; align-items: center; gap: 8px">
+                <ion-icon
+                  [name]="categoryGroup.icon"
+                  [color]="categoryGroup.color"
+                ></ion-icon>
+                {{ categoryGroup.category }} ({{ categoryGroup.roles.length }})
+              </span>
               <ion-icon
-                [name]="categoryGroup.icon"
-                [color]="categoryGroup.color"
+                [name]="
+                  isCategoryCollapsed(categoryGroup.category)
+                    ? 'chevron-down'
+                    : 'chevron-up'
+                "
               ></ion-icon>
-              {{ categoryGroup.category }} ({{ categoryGroup.roles.length }})
             </h3>
           </div>
 
-          <!-- Column Headers for this category -->
-          <ion-grid style="margin-left: 16px">
-            <ion-row
-              class="ion-text-center"
-              style="
-                font-weight: bold;
-                border-bottom: 1px solid var(--ion-color-medium);
-                padding-bottom: 8px;
-                margin-bottom: 8px;
-                color: var(--ion-color-dark);
-              "
-            >
-              <ion-col align="left" size="3">Current Info</ion-col>
-              <ion-col align="left" size="2">Name</ion-col>
-              <ion-col align="left" size="2">Description</ion-col>
-              <ion-col align="left" size="1.5">Type</ion-col>
-              <ion-col align="left" size="1.5">Parent Role</ion-col>
-              <ion-col align="left" size="2">Actions</ion-col>
-            </ion-row>
-          </ion-grid>
+          <ng-container *ngIf="!isCategoryCollapsed(categoryGroup.category)">
+            <!-- Column Headers for this category -->
+            <ion-grid style="margin-left: 16px">
+              <ion-row
+                class="ion-text-center"
+                style="
+                  font-weight: bold;
+                  border-bottom: 1px solid var(--ion-color-medium);
+                  padding-bottom: 8px;
+                  margin-bottom: 8px;
+                  color: var(--ion-color-dark);
+                "
+              >
+                <ion-col align="left" size="3">Current Info</ion-col>
+                <ion-col align="left" size="2">Name</ion-col>
+                <ion-col align="left" size="2">Description</ion-col>
+                <ion-col align="left" size="1.5">Type</ion-col>
+                <ion-col align="left" size="1.5">Parent Role</ion-col>
+                <ion-col align="left" size="2">Actions</ion-col>
+              </ion-row>
+            </ion-grid>
 
-          <!-- Roles in this category -->
-          <ion-grid
-            *ngFor="let role of categoryGroup.roles"
-            class="role-row"
-            style="margin-left: 16px"
-          >
-            <ion-row style="color: var(--ion-color-dark)">
-              <ion-col size="3" class="role-info-display">
-                <div style="display: flex; align-items: center; gap: 8px">
-                  <ion-icon
-                    [name]="role.icon || getRoleIcon(role)"
-                    style="font-size: 24px; color: var(--ion-color-primary)"
-                  ></ion-icon>
-                  <div>
-                    <h3
-                      style="
-                        font-weight: bold;
-                        color: var(--ion-color-primary);
-                        margin: 0;
-                        display: flex;
-                        align-items: center;
-                        gap: 6px;
-                      "
-                    >
-                      {{ role.name }}
-                      <span
-                        *ngIf="role.isStandardRole"
-                        class="role-badge standard-role"
+            <!-- Roles in this category -->
+            <ion-grid
+              *ngFor="let role of categoryGroup.roles"
+              class="role-row"
+              style="margin-left: 16px"
+            >
+              <ion-row style="color: var(--ion-color-dark)">
+                <ion-col size="3" class="role-info-display">
+                  <div style="display: flex; align-items: center; gap: 8px">
+                    <ion-icon
+                      [name]="role.icon || getRoleIcon(role)"
+                      style="font-size: 24px; color: var(--ion-color-primary)"
+                    ></ion-icon>
+                    <div>
+                      <h3
+                        style="
+                          font-weight: bold;
+                          color: var(--ion-color-primary);
+                          margin: 0;
+                          display: flex;
+                          align-items: center;
+                          gap: 6px;
+                        "
                       >
-                        <ion-icon name="library" size="small"></ion-icon>
-                        Standard
-                      </span>
-                      <span
-                        *ngIf="role.isCustomRole"
-                        class="role-badge custom-role"
+                        {{ role.name }}
+                        <span
+                          *ngIf="role.isStandardRole"
+                          class="role-badge standard-role"
+                        >
+                          <ion-icon name="library" size="small"></ion-icon>
+                          Standard
+                        </span>
+                        <span
+                          *ngIf="role.isCustomRole"
+                          class="role-badge custom-role"
+                        >
+                          <ion-icon name="create" size="small"></ion-icon>
+                          Custom
+                        </span>
+                      </h3>
+                      <p
+                        style="
+                          color: var(--ion-color-secondary);
+                          margin: 4px 0 0 0;
+                          font-size: 0.9rem;
+                        "
                       >
-                        <ion-icon name="create" size="small"></ion-icon>
-                        Custom
-                      </span>
-                    </h3>
-                    <p
-                      style="
-                        color: var(--ion-color-secondary);
-                        margin: 4px 0 0 0;
-                        font-size: 0.9rem;
-                      "
-                    >
-                      Parent: {{ getParentName(role.parentRoleId, (roles$ |
-                      async) || []) || 'None' }}<br />
-                      Type: {{ role.roleType || 'organization' | titlecase }}<br />
-                      <span *ngIf="role.standardCategory"
-                        >Category: {{ role.standardCategory }}</span
-                      >
-                      <span *ngIf="role.standardCategory && role.description"
-                        ><br
-                      /></span>
-                      {{ role.description }}
-                    </p>
+                        Parent: {{ getParentName(role.parentRoleId, (roles$ |
+                        async) || []) || 'None' }}<br />
+                        Type: {{ role.roleType || 'organization' | titlecase }}<br />
+                        <span *ngIf="role.standardCategory"
+                          >Category: {{ role.standardCategory }}</span
+                        >
+                        <span *ngIf="
+                          role.standardCategory && role.description
+                        "
+                          ><br
+                        /></span>
+                        {{ role.description }}
+                      </p>
+                    </div>
                   </div>
-                </div>
-              </ion-col>
-              <ion-col size="2">
-                <ion-input
-                  [(ngModel)]="role.name"
-                  placeholder="Name"
-                  maxlength="50"
-                  (ionBlur)="updateRole(role)"
-                ></ion-input>
-              </ion-col>
-              <ion-col size="2">
-                <ion-input
-                  [(ngModel)]="role.description"
-                  placeholder="Description"
-                  maxlength="150"
-                  (ionBlur)="updateRole(role)"
-                ></ion-input>
-              </ion-col>
-              <ion-col size="1.5">
-                <ion-select
-                  [(ngModel)]="role.roleType"
-                  placeholder="Type"
-                  (ionChange)="updateRole(role)"
-                >
-                  <ion-select-option value="organization"
-                    >Organization</ion-select-option
+                </ion-col>
+                <ion-col size="2">
+                  <ion-input
+                    [(ngModel)]="role.name"
+                    placeholder="Name"
+                    maxlength="50"
+                    (ionBlur)="updateRole(role)"
+                  ></ion-input>
+                </ion-col>
+                <ion-col size="2">
+                  <ion-input
+                    [(ngModel)]="role.description"
+                    placeholder="Description"
+                    maxlength="150"
+                    (ionBlur)="updateRole(role)"
+                  ></ion-input>
+                </ion-col>
+                <ion-col size="1.5">
+                  <ion-select
+                    [(ngModel)]="role.roleType"
+                    placeholder="Type"
+                    (ionChange)="updateRole(role)"
                   >
-                  <ion-select-option value="user">User</ion-select-option>
-                </ion-select>
-              </ion-col>
-              <ion-col size="1.5">
-                <ion-select
-                  [(ngModel)]="role.parentRoleId"
-                  placeholder="Parent (same category)"
-                  (ionChange)="updateRole(role)"
-                >
-                  <ion-select-option [value]="undefined"
-                    >None</ion-select-option
+                    <ion-select-option value="organization"
+                      >Organization</ion-select-option
+                    >
+                    <ion-select-option value="user">User</ion-select-option>
+                  </ion-select>
+                </ion-col>
+                <ion-col size="1.5">
+                  <ion-select
+                    [(ngModel)]="role.parentRoleId"
+                    placeholder="Parent (same category)"
+                    (ionChange)="updateRole(role)"
                   >
-                  <ion-select-option
-                    *ngFor="let parent of getAvailableParentRoles(role, (roles$ | async) || [])"
-                    [value]="parent.id"
-                  >
-                    {{ parent.name }}
-                  </ion-select-option>
-                </ion-select>
-              </ion-col>
-              <ion-col size="2">
-                <ion-button color="danger" (click)="deleteRole(role)">
-                  Delete
-                </ion-button>
-              </ion-col>
-            </ion-row>
-          </ion-grid>
+                    <ion-select-option [value]="undefined"
+                      >None</ion-select-option
+                    >
+                    <ion-select-option
+                      *ngFor="let parent of getAvailableParentRoles(role, (roles$ | async) || [])"
+                      [value]="parent.id"
+                    >
+                      {{ parent.name }}
+                    </ion-select-option>
+                  </ion-select>
+                </ion-col>
+                <ion-col size="2">
+                  <ion-button color="danger" (click)="deleteRole(role)">
+                    Delete
+                  </ion-button>
+                </ion-col>
+              </ion-row>
+            </ion-grid>
+          </ng-container>
         </div>
       </ion-card-content>
     </ion-card>

--- a/src/app/modules/account/pages/role-management/role-management.page.html
+++ b/src/app/modules/account/pages/role-management/role-management.page.html
@@ -11,7 +11,7 @@
       </ion-card-header>
       <ion-card-content>
         <!-- Display roles grouped by category -->
-        <div *ngFor="let categoryGroup of categorizedRoles$ | async">
+        <div *ngFor="let categoryGroup of categorizedRoles$ | async; trackBy: trackCategory">
           <!-- Category Header -->
           <div
             class="category-header"
@@ -75,7 +75,7 @@
 
             <!-- Roles in this category -->
             <ion-grid
-              *ngFor="let role of categoryGroup.roles"
+              *ngFor="let role of categoryGroup.roles; trackBy: trackRole"
               class="role-row"
               style="margin-left: 16px"
             >

--- a/src/app/modules/account/pages/role-management/role-management.page.ts
+++ b/src/app/modules/account/pages/role-management/role-management.page.ts
@@ -61,6 +61,11 @@ export class RoleManagementPage implements OnInit {
 
   // For account info to pass to standard role selector
   currentAccount?: Account;
+
+  /** Tracks which role categories are collapsed on the page */
+  private collapsedCategories = new Set<
+    StandardRoleCategory | "Uncategorized"
+  >();
   constructor(
     private route: ActivatedRoute,
     private store: Store,
@@ -202,6 +207,20 @@ export class RoleManagementPage implements OnInit {
     this.store.dispatch(
       AccountActions.createGroupRole({groupId: this.groupId, role}),
     );
+  }
+
+  /** Toggles the collapsed state of a role category */
+  toggleCategory(category: StandardRoleCategory | "Uncategorized") {
+    if (this.collapsedCategories.has(category)) {
+      this.collapsedCategories.delete(category);
+    } else {
+      this.collapsedCategories.add(category);
+    }
+  }
+
+  /** Checks whether the provided category is currently collapsed */
+  isCategoryCollapsed(category: StandardRoleCategory | "Uncategorized") {
+    return this.collapsedCategories.has(category);
   }
 
   private groupRolesByCategory(roles: GroupRole[]): CategorizedRoles[] {


### PR DESCRIPTION
## Summary
- Make role category tables collapsible on the role management page
- Refresh available templates when roles change and hide a selected template immediately

## Testing
- `npm run lint` *(fails: Lint errors in unrelated files)*
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68a51fd609f48326bcab64309967eb1d