### PR TITLE
feat(chat-list): show avatars and decrypt last message

### DIFF
--- a/src/app/modules/messaging/pages/chat-list/chat-list.page.html
+++ b/src/app/modules/messaging/pages/chat-list/chat-list.page.html
@@ -33,15 +33,21 @@
       (click)="openChat(chat)"
       detail="false"
     >
-      <!-- Profile Picture Placeholder -->
+      <!-- Profile Picture -->
       <ion-avatar slot="start">
-        <ion-icon name="person-circle" size="large"></ion-icon>
+        <img
+          *ngIf="getChatAvatar(chat); else defaultAvatar"
+          [src]="getChatAvatar(chat)"
+        />
+        <ng-template #defaultAvatar>
+          <ion-icon name="person-circle" size="large"></ion-icon>
+        </ng-template>
       </ion-avatar>
 
       <!-- Chat Info -->
       <ion-label>
         <h2>{{ getChatDisplayName(chat) }}</h2>
-        <p>{{ getTruncatedMessage(chat.lastMessage) }}</p>
+        <p>{{ getTruncatedMessage(getLastMessage(chat)) }}</p>
       </ion-label>
 
       <!-- Timestamp and Unread Badge -->


### PR DESCRIPTION
## Summary
- load participant avatars in chat list and fall back to default icon
- decrypt last messages before rendering and cache results

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: Lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a54f00f770832688d4021a1ab6187c