### PR TITLE
feat: add Google Play link to landing page

### DIFF
--- a/src/app/modules/info/pages/landing/landing.page.html
+++ b/src/app/modules/info/pages/landing/landing.page.html
@@ -60,6 +60,13 @@ along with Nonprofit Social Networking Platform.  If not, see <https://www.gnu.o
           <ion-button routerLink="/auth/signup" color="primary"
             >Try Now</ion-button
           >
+          <ion-button
+            href="https://play.google.com/store/apps/details?id=org.ascendcoopplatform.app&pcampaignid=web_share"
+            target="_blank"
+            rel="noopener"
+            color="medium"
+            >Get it on Google Play</ion-button
+          >
         </ion-col>
         <ion-col size="12" size-md="12" class="hero-image">
           <swiper-container


### PR DESCRIPTION
## Summary
- add Google Play badge link to hero section of landing page

## Testing
- `CHROME_BIN=$(which chromium-browser) npm test` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a54fbbe5c48326afa03df9eba99370